### PR TITLE
Bump to v0.6.1: fix context key init and BSD grep portability

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if grep -q 'mthds-ui.*portal:\|mthds-ui.*file:' editors/vscode/package.json 2>/dev/null; then
+if grep -qE 'mthds-ui.*(portal:|file:)' editors/vscode/package.json 2>/dev/null; then
     echo "ERROR: Local mthds-ui link detected in editors/vscode/package.json."
     echo "Run 'make use-github' before committing."
     exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__/
 dist/
 wheels/
 .cursor/plans
+.gstack/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [0.6.1] - 2026-04-02
 
+### Changed
+- Upgrade @pipelex/mthds-ui to v0.2.2 (fix bullet alignment in StuffViewer HTML lists)
+
 ### Fixed
 - Fix GraphSpec JSON context key not initialized when extension activates with a JSON file already open — "Show Run Graph" button was invisible until switching editors
 - Fix pre-commit hook and Makefile local-deps guard using GNU-only grep syntax that silently passes on macOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Pipelex IDE Extension and `plxt` CLI Changelog
 
+## [0.6.1] - 2026-04-02
+
+### Fixed
+- Fix GraphSpec JSON context key not initialized when extension activates with a JSON file already open — "Show Run Graph" button was invisible until switching editors
+- Fix pre-commit hook and Makefile local-deps guard using GNU-only grep syntax that silently passes on macOS
+
 ## [0.6.0] - 2026-04-02
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ test: ## Run all tests (Rust + VS Code extension)
 	cd $(EXT_DIR) && yarn test
 
 check-no-local-deps: ## Fail if a local mthds-ui link would be committed
-	@! grep -q 'mthds-ui.*portal:\|mthds-ui.*file:' $(EXT_DIR)/package.json || \
+	@! grep -qE 'mthds-ui.*(portal:|file:)' $(EXT_DIR)/package.json || \
 		{ echo "ERROR: Local mthds-ui link in $(EXT_DIR)/package.json. Run 'make use-github' first."; exit 1; }
 
 setup-hooks: ## Configure git to use .githooks/ for hooks

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "pipelex",
   "displayName": "Pipelex",
   "description": "Pipelex extension for the MTHDS language",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "repository": {
     "url": "https://github.com/Pipelex/vscode-pipelex"
   },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -747,7 +747,7 @@
   },
   "dependencies": {
     "@pipelex/lsp": "portal:../../js/lsp",
-    "@pipelex/mthds-ui": "github:Pipelex/mthds-ui#82d413a0800b565a7eb4965500e1aa01129d63d0",
+    "@pipelex/mthds-ui": "github:Pipelex/mthds-ui#8f8e7ff1d4ca56b51051de11dfc9d614cf64c7aa",
     "deep-equal": "^2.2.3",
     "encoding": "^0.1.13",
     "fast-glob": "^3.3.2",

--- a/editors/vscode/src/pipelex/pipelexExtension.ts
+++ b/editors/vscode/src/pipelex/pipelexExtension.ts
@@ -117,6 +117,18 @@ async function registerNodeFeatures(
         })
     );
 
+    // Initialize context key for the already-active editor (the event doesn't fire for it)
+    {
+        const activeEditor = vscode.window.activeTextEditor;
+        let isGraphspec = false;
+        if (activeEditor?.document.languageId === 'json' && activeEditor.document.uri.scheme === 'file') {
+            try {
+                isGraphspec = isGraphspecJson(activeEditor.document.getText());
+            } catch { /* ignore */ }
+        }
+        vscode.commands.executeCommand('setContext', 'pipelex.isGraphspecJson', isGraphspec);
+    }
+
     context.subscriptions.push(
         vscode.window.registerWebviewPanelSerializer('pipelexMethodGraph', {
             async deserializeWebviewPanel(panel: vscode.WebviewPanel, state: any) {

--- a/editors/vscode/yarn.lock
+++ b/editors/vscode/yarn.lock
@@ -483,9 +483,9 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@pipelex/mthds-ui@github:Pipelex/mthds-ui#82d413a0800b565a7eb4965500e1aa01129d63d0":
-  version: 0.2.1
-  resolution: "@pipelex/mthds-ui@https://github.com/Pipelex/mthds-ui.git#commit=82d413a0800b565a7eb4965500e1aa01129d63d0"
+"@pipelex/mthds-ui@github:Pipelex/mthds-ui#8f8e7ff1d4ca56b51051de11dfc9d614cf64c7aa":
+  version: 0.2.2
+  resolution: "@pipelex/mthds-ui@https://github.com/Pipelex/mthds-ui.git#commit=8f8e7ff1d4ca56b51051de11dfc9d614cf64c7aa"
   dependencies:
     "@xyflow/react": "npm:^12"
     dompurify: "npm:^3.3.3"
@@ -501,7 +501,7 @@ __metadata:
       optional: true
     shiki:
       optional: true
-  checksum: b98c17eb5ef49e2d00d879afaec4b1ad2d29e7a7fc46acbcd382b18fca1fc554692c54b66695a890160f954e36fbf0644fd128071b876e040715179148d3864e
+  checksum: 0622a74a2dbc7657a1ae262f8aa8f816c15881162df7b4cd62a4be2587e427342a80800d0bc01f5383f00248538fc83789318c97b597946a6c48de5939a16f6c
   languageName: node
   linkType: hard
 
@@ -3471,7 +3471,7 @@ __metadata:
   resolution: "pipelex@workspace:."
   dependencies:
     "@pipelex/lsp": "portal:../../js/lsp"
-    "@pipelex/mthds-ui": "github:Pipelex/mthds-ui#82d413a0800b565a7eb4965500e1aa01129d63d0"
+    "@pipelex/mthds-ui": "github:Pipelex/mthds-ui#8f8e7ff1d4ca56b51051de11dfc9d614cf64c7aa"
     "@rollup/plugin-commonjs": "npm:^25.0.7"
     "@rollup/plugin-node-resolve": "npm:^15.2.3"
     "@rollup/plugin-replace": "npm:^5.0.5"


### PR DESCRIPTION
Initialize the isGraphspecJson context key for the already-active editor at activation time, so the "Show Run Graph" button appears immediately.

Switch pre-commit hook and Makefile local-deps guard from GNU-only BRE alternation (\|) to portable ERE (-qE), fixing silent pass-through on macOS BSD grep.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.6.1 with fixes: the "Show Run Graph" button appears on startup, grep-based checks work on macOS, and StuffViewer list bullets render correctly.

- **Bug Fixes**
  - VS Code: initialize the `pipelex.isGraphspecJson` context at activation so the "Show Run Graph" button is visible without switching tabs.
  - Tooling: use portable ERE with `-qE` in `.githooks/pre-commit` and `Makefile` to avoid silent pass-through on BSD/macOS.
  - UI: upgrade `@pipelex/mthds-ui` to v0.2.2 to fix bullet alignment in StuffViewer HTML lists.

<sup>Written for commit fb7ac31de68f6b1e036a9edb6f20f6204b181309. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

