### PR TITLE
feature/sidepanel

### DIFF
--- a/editors/vscode/scripts/build.mjs
+++ b/editors/vscode/scripts/build.mjs
@@ -43,6 +43,10 @@ cpSync(
   "./node_modules/@pipelex/mthds-ui/dist/graph/react/stuff/StuffViewer.css",
   "./dist/pipelex/graph/webview/stuff-viewer.css",
 );
+cpSync(
+  "./node_modules/@pipelex/mthds-ui/dist/graph/react/detail/DetailPanel.css",
+  "./dist/pipelex/graph/webview/detail-panel.css",
+);
 
 // Bundle webview TypeScript → single IIFE script
 // React, ReactDOM, @xyflow/react v12, dagre, and mthds-ui are all bundled.

--- a/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
+++ b/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
@@ -448,11 +448,13 @@ export class MethodGraphPanel implements vscode.Disposable {
         const xyflowCssUri = this.panel.webview.asWebviewUri(vscode.Uri.joinPath(webviewDir, 'xyflow.css'));
         const graphCoreCssUri = this.panel.webview.asWebviewUri(vscode.Uri.joinPath(webviewDir, 'graph-core.css'));
         const stuffViewerCssUri = this.panel.webview.asWebviewUri(vscode.Uri.joinPath(webviewDir, 'stuff-viewer.css'));
+        const detailPanelCssUri = this.panel.webview.asWebviewUri(vscode.Uri.joinPath(webviewDir, 'detail-panel.css'));
 
         html = html.replace('{{XYFLOW_CSS_URI}}', xyflowCssUri.toString());
         html = html.replace('{{GRAPH_CORE_CSS_URI}}', graphCoreCssUri.toString());
         html = html.replace('{{GRAPH_CSS_URI}}', cssUri.toString());
         html = html.replace('{{STUFF_VIEWER_CSS_URI}}', stuffViewerCssUri.toString());
+        html = html.replace('{{DETAIL_PANEL_CSS_URI}}', detailPanelCssUri.toString());
         html = html.replace('{{GRAPH_JS_URI}}', jsUri.toString());
 
         return html;

--- a/editors/vscode/src/pipelex/graph/webview/adapter.ts
+++ b/editors/vscode/src/pipelex/graph/webview/adapter.ts
@@ -1,8 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import type { GraphSpec, GraphConfig, GraphDirection } from '@pipelex/mthds-ui';
-import { GraphViewer, StuffViewer } from '@pipelex/mthds-ui/graph/react';
-import type { StuffViewerData } from '@pipelex/mthds-ui/graph/react';
+import { GraphViewer } from '@pipelex/mthds-ui/graph/react';
 
 // VS Code webview API
 const vscode = acquireVsCodeApi();
@@ -25,10 +24,6 @@ let currentShowControllers = false;
 let currentUri: string | null = null;
 let renderApp: (() => void) | null = null;
 
-// Stuff inspector state
-let currentStuffData: StuffViewerData | null = null;
-let stuffRoot: ReturnType<typeof createRoot> | null = null;
-
 // Expose ReactFlow instance for zoom toolbar buttons
 let reactFlowInstance: any = null;
 
@@ -37,12 +32,6 @@ function applyDirectionIcon(direction: string) {
     document.querySelectorAll('.direction-icon').forEach(icon => icon.classList.remove('active'));
     const targetIcon = document.querySelector(direction === 'LR' ? '.tb-icon' : '.lr-icon');
     if (targetIcon) targetIcon.classList.add('active');
-}
-
-// Show/hide the stuff inspector panel
-function showInspector(visible: boolean) {
-    const el = document.getElementById('stuff-inspector');
-    if (el) el.style.display = visible ? 'flex' : 'none';
 }
 
 // Direction toggle button
@@ -72,13 +61,6 @@ controllersToggle.addEventListener('change', () => {
     if (renderApp) renderApp();
 });
 
-// Stuff inspector close button
-document.getElementById('stuff-inspector-close')!.addEventListener('click', () => {
-    currentStuffData = null;
-    showInspector(false);
-    if (renderApp) renderApp();
-});
-
 // --- Callbacks passed to GraphViewer ---
 
 function onNavigateToPipe(pipeCode: string) {
@@ -88,12 +70,6 @@ function onNavigateToPipe(pipeCode: string) {
 function onReactFlowInit(instance: any) {
     reactFlowInstance = instance;
     (window as any)._reactFlowInstance = instance;
-}
-
-function onStuffNodeClick(stuffData: StuffViewerData) {
-    currentStuffData = stuffData;
-    showInspector(true);
-    if (renderApp) renderApp();
 }
 
 // --- Message handling ---
@@ -130,10 +106,6 @@ function handleMessage(event: { data: any }) {
         controllersToggle.checked = currentShowControllers;
         applyDirectionIcon(currentDirection);
 
-        // Clear stuff inspector on new graph data
-        currentStuffData = null;
-        showInspector(false);
-
         // Apply palette colors as CSS custom properties on <body>
         if (currentConfig.paletteColors) {
             for (const [cssVar, value] of Object.entries(currentConfig.paletteColors)) {
@@ -168,7 +140,6 @@ function App() {
         direction: currentDirection,
         showControllers: currentShowControllers,
         onNavigateToPipe,
-        onStuffNodeClick,
         onReactFlowInit,
     });
 }
@@ -178,16 +149,6 @@ const root = createRoot(document.getElementById('root')!);
 
 renderApp = () => {
     root.render(React.createElement(App));
-
-    // Render StuffViewer in inspector panel
-    if (currentStuffData) {
-        if (!stuffRoot) {
-            stuffRoot = createRoot(document.getElementById('stuff-viewer-root')!);
-        }
-        stuffRoot.render(React.createElement(StuffViewer, { stuff: currentStuffData }));
-    } else if (stuffRoot) {
-        stuffRoot.render(null);
-    }
 };
 renderApp();
 

--- a/editors/vscode/src/pipelex/graph/webview/graph.html
+++ b/editors/vscode/src/pipelex/graph/webview/graph.html
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="{{GRAPH_CORE_CSS_URI}}">
 <link rel="stylesheet" href="{{GRAPH_CSS_URI}}">
 <link rel="stylesheet" href="{{STUFF_VIEWER_CSS_URI}}">
+<link rel="stylesheet" href="{{DETAIL_PANEL_CSS_URI}}">
 </head>
 <body>
 <div class="toolbar">
@@ -29,15 +30,6 @@
 </div>
 <div id="app-container">
     <div id="root"></div>
-    <div id="stuff-inspector" class="stuff-inspector" style="display: none;">
-        <div class="stuff-inspector-header">
-            <span class="stuff-inspector-title">Inspector</span>
-            <button id="stuff-inspector-close" class="toolbar-btn" title="Close inspector">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
-            </button>
-        </div>
-        <div id="stuff-viewer-root"></div>
-    </div>
 </div>
 
 <script nonce="PIPELEX_CSP_NONCE" src="{{GRAPH_JS_URI}}"></script>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Implements the new side panel by adopting `@pipelex/mthds-ui`’s built-in Detail Panel in the VS Code method graph webview. Removes the legacy Stuff Inspector and its logic.

- **Refactors**
  - Build now copies `DetailPanel.css` from `@pipelex/mthds-ui` and includes it in the webview.
  - Injects `{{DETAIL_PANEL_CSS_URI}}` in `methodGraphPanel.ts` and links it in `graph.html`.
  - Removes `StuffViewer` and the inspector UI: imports, state, close button, and `onStuffNodeClick`; node details are handled within `GraphViewer`.

<sup>Written for commit ab286dd7425e4fd9e04e0e74be340da92d94d196. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

