### PR TITLE
Release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Pipelex IDE Extension and `plxt` CLI Changelog
 
+## [0.6.2] - 2026-04-06
+
+### Changed
+- Replace custom Stuff Inspector side panel with mthds-ui's built-in Detail Panel inside GraphViewer — node details now render inline without a separate panel
+
 ## [0.6.1] - 2026-04-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.6.2] - 2026-04-06
 
 ### Changed
+- Upgrade @pipelex/mthds-ui to v0.2.3 (built-in Detail Panel support)
 - Replace custom Stuff Inspector side panel with mthds-ui's built-in Detail Panel inside GraphViewer — node details now render inline without a separate panel
 
 ## [0.6.1] - 2026-04-02

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -747,7 +747,7 @@
   },
   "dependencies": {
     "@pipelex/lsp": "portal:../../js/lsp",
-    "@pipelex/mthds-ui": "github:Pipelex/mthds-ui#8f8e7ff1d4ca56b51051de11dfc9d614cf64c7aa",
+    "@pipelex/mthds-ui": "github:Pipelex/mthds-ui#9884169254aa82d7e6d576f99f83ba914a856490",
     "deep-equal": "^2.2.3",
     "encoding": "^0.1.13",
     "fast-glob": "^3.3.2",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "pipelex",
   "displayName": "Pipelex",
   "description": "Pipelex extension for the MTHDS language",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "repository": {
     "url": "https://github.com/Pipelex/vscode-pipelex"
   },

--- a/editors/vscode/scripts/build.mjs
+++ b/editors/vscode/scripts/build.mjs
@@ -43,6 +43,10 @@ cpSync(
   "./node_modules/@pipelex/mthds-ui/dist/graph/react/stuff/StuffViewer.css",
   "./dist/pipelex/graph/webview/stuff-viewer.css",
 );
+cpSync(
+  "./node_modules/@pipelex/mthds-ui/dist/graph/react/detail/DetailPanel.css",
+  "./dist/pipelex/graph/webview/detail-panel.css",
+);
 
 // Bundle webview TypeScript → single IIFE script
 // React, ReactDOM, @xyflow/react v12, dagre, and mthds-ui are all bundled.

--- a/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
+++ b/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
@@ -448,11 +448,13 @@ export class MethodGraphPanel implements vscode.Disposable {
         const xyflowCssUri = this.panel.webview.asWebviewUri(vscode.Uri.joinPath(webviewDir, 'xyflow.css'));
         const graphCoreCssUri = this.panel.webview.asWebviewUri(vscode.Uri.joinPath(webviewDir, 'graph-core.css'));
         const stuffViewerCssUri = this.panel.webview.asWebviewUri(vscode.Uri.joinPath(webviewDir, 'stuff-viewer.css'));
+        const detailPanelCssUri = this.panel.webview.asWebviewUri(vscode.Uri.joinPath(webviewDir, 'detail-panel.css'));
 
         html = html.replace('{{XYFLOW_CSS_URI}}', xyflowCssUri.toString());
         html = html.replace('{{GRAPH_CORE_CSS_URI}}', graphCoreCssUri.toString());
         html = html.replace('{{GRAPH_CSS_URI}}', cssUri.toString());
         html = html.replace('{{STUFF_VIEWER_CSS_URI}}', stuffViewerCssUri.toString());
+        html = html.replace('{{DETAIL_PANEL_CSS_URI}}', detailPanelCssUri.toString());
         html = html.replace('{{GRAPH_JS_URI}}', jsUri.toString());
 
         return html;

--- a/editors/vscode/src/pipelex/graph/webview/adapter.ts
+++ b/editors/vscode/src/pipelex/graph/webview/adapter.ts
@@ -1,8 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import type { GraphSpec, GraphConfig, GraphDirection } from '@pipelex/mthds-ui';
-import { GraphViewer, StuffViewer } from '@pipelex/mthds-ui/graph/react';
-import type { StuffViewerData } from '@pipelex/mthds-ui/graph/react';
+import { GraphViewer } from '@pipelex/mthds-ui/graph/react';
 
 // VS Code webview API
 const vscode = acquireVsCodeApi();
@@ -25,10 +24,6 @@ let currentShowControllers = false;
 let currentUri: string | null = null;
 let renderApp: (() => void) | null = null;
 
-// Stuff inspector state
-let currentStuffData: StuffViewerData | null = null;
-let stuffRoot: ReturnType<typeof createRoot> | null = null;
-
 // Expose ReactFlow instance for zoom toolbar buttons
 let reactFlowInstance: any = null;
 
@@ -37,12 +32,6 @@ function applyDirectionIcon(direction: string) {
     document.querySelectorAll('.direction-icon').forEach(icon => icon.classList.remove('active'));
     const targetIcon = document.querySelector(direction === 'LR' ? '.tb-icon' : '.lr-icon');
     if (targetIcon) targetIcon.classList.add('active');
-}
-
-// Show/hide the stuff inspector panel
-function showInspector(visible: boolean) {
-    const el = document.getElementById('stuff-inspector');
-    if (el) el.style.display = visible ? 'flex' : 'none';
 }
 
 // Direction toggle button
@@ -72,13 +61,6 @@ controllersToggle.addEventListener('change', () => {
     if (renderApp) renderApp();
 });
 
-// Stuff inspector close button
-document.getElementById('stuff-inspector-close')!.addEventListener('click', () => {
-    currentStuffData = null;
-    showInspector(false);
-    if (renderApp) renderApp();
-});
-
 // --- Callbacks passed to GraphViewer ---
 
 function onNavigateToPipe(pipeCode: string) {
@@ -88,12 +70,6 @@ function onNavigateToPipe(pipeCode: string) {
 function onReactFlowInit(instance: any) {
     reactFlowInstance = instance;
     (window as any)._reactFlowInstance = instance;
-}
-
-function onStuffNodeClick(stuffData: StuffViewerData) {
-    currentStuffData = stuffData;
-    showInspector(true);
-    if (renderApp) renderApp();
 }
 
 // --- Message handling ---
@@ -130,10 +106,6 @@ function handleMessage(event: { data: any }) {
         controllersToggle.checked = currentShowControllers;
         applyDirectionIcon(currentDirection);
 
-        // Clear stuff inspector on new graph data
-        currentStuffData = null;
-        showInspector(false);
-
         // Apply palette colors as CSS custom properties on <body>
         if (currentConfig.paletteColors) {
             for (const [cssVar, value] of Object.entries(currentConfig.paletteColors)) {
@@ -168,7 +140,6 @@ function App() {
         direction: currentDirection,
         showControllers: currentShowControllers,
         onNavigateToPipe,
-        onStuffNodeClick,
         onReactFlowInit,
     });
 }
@@ -178,16 +149,6 @@ const root = createRoot(document.getElementById('root')!);
 
 renderApp = () => {
     root.render(React.createElement(App));
-
-    // Render StuffViewer in inspector panel
-    if (currentStuffData) {
-        if (!stuffRoot) {
-            stuffRoot = createRoot(document.getElementById('stuff-viewer-root')!);
-        }
-        stuffRoot.render(React.createElement(StuffViewer, { stuff: currentStuffData }));
-    } else if (stuffRoot) {
-        stuffRoot.render(null);
-    }
 };
 renderApp();
 

--- a/editors/vscode/src/pipelex/graph/webview/graph.html
+++ b/editors/vscode/src/pipelex/graph/webview/graph.html
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="{{GRAPH_CORE_CSS_URI}}">
 <link rel="stylesheet" href="{{GRAPH_CSS_URI}}">
 <link rel="stylesheet" href="{{STUFF_VIEWER_CSS_URI}}">
+<link rel="stylesheet" href="{{DETAIL_PANEL_CSS_URI}}">
 </head>
 <body>
 <div class="toolbar">
@@ -29,15 +30,6 @@
 </div>
 <div id="app-container">
     <div id="root"></div>
-    <div id="stuff-inspector" class="stuff-inspector" style="display: none;">
-        <div class="stuff-inspector-header">
-            <span class="stuff-inspector-title">Inspector</span>
-            <button id="stuff-inspector-close" class="toolbar-btn" title="Close inspector">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
-            </button>
-        </div>
-        <div id="stuff-viewer-root"></div>
-    </div>
 </div>
 
 <script nonce="PIPELEX_CSP_NONCE" src="{{GRAPH_JS_URI}}"></script>

--- a/editors/vscode/yarn.lock
+++ b/editors/vscode/yarn.lock
@@ -483,9 +483,9 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@pipelex/mthds-ui@github:Pipelex/mthds-ui#8f8e7ff1d4ca56b51051de11dfc9d614cf64c7aa":
+"@pipelex/mthds-ui@github:Pipelex/mthds-ui#9884169254aa82d7e6d576f99f83ba914a856490":
   version: 0.2.2
-  resolution: "@pipelex/mthds-ui@https://github.com/Pipelex/mthds-ui.git#commit=8f8e7ff1d4ca56b51051de11dfc9d614cf64c7aa"
+  resolution: "@pipelex/mthds-ui@https://github.com/Pipelex/mthds-ui.git#commit=9884169254aa82d7e6d576f99f83ba914a856490"
   dependencies:
     "@xyflow/react": "npm:^12"
     dompurify: "npm:^3.3.3"
@@ -501,7 +501,7 @@ __metadata:
       optional: true
     shiki:
       optional: true
-  checksum: 0622a74a2dbc7657a1ae262f8aa8f816c15881162df7b4cd62a4be2587e427342a80800d0bc01f5383f00248538fc83789318c97b597946a6c48de5939a16f6c
+  checksum: a02b28285445540c60aac8045c42dd1e01146d0f731795b123b5d947bebb6f82dfaf5f6f7fdc27dfebb266137a7274454452929fa6eecfe87d55fcc0bc61bf58
   languageName: node
   linkType: hard
 
@@ -3471,7 +3471,7 @@ __metadata:
   resolution: "pipelex@workspace:."
   dependencies:
     "@pipelex/lsp": "portal:../../js/lsp"
-    "@pipelex/mthds-ui": "github:Pipelex/mthds-ui#8f8e7ff1d4ca56b51051de11dfc9d614cf64c7aa"
+    "@pipelex/mthds-ui": "github:Pipelex/mthds-ui#9884169254aa82d7e6d576f99f83ba914a856490"
     "@rollup/plugin-commonjs": "npm:^25.0.7"
     "@rollup/plugin-node-resolve": "npm:^15.2.3"
     "@rollup/plugin-replace": "npm:^5.0.5"


### PR DESCRIPTION
## Summary
- Bump extension version from 0.6.1 → 0.6.2
- Replace custom Stuff Inspector side panel with mthds-ui's built-in Detail Panel inside GraphViewer — node details now render inline without a separate panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.6.2 replaces the custom inspector with the built‑in Detail Panel from `@pipelex/mthds-ui`, so node details render inline in GraphViewer. Also bumps the VS Code extension to 0.6.2 and updates `@pipelex/mthds-ui` to v0.2.3.

- **Refactors**
  - Removed custom Stuff Inspector UI and `StuffViewer` wiring from the webview adapter and HTML.
  - Added `DetailPanel.css` to the build and loaded it in the webview.
  - Updated the changelog and version in `package.json`.

<sup>Written for commit 90b483bd94d8b7fdef86c29ce9e995dd48da5cb6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

