### PR TITLE
feature/reqwest-client-when-needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Pipelex IDE Extension and `plxt` CLI Changelog
 
+## [Unreleased]
+
+### Fixed
+- Fix `plxt` crashing in sandboxed environments (Codex, CI containers) due to eager HTTP client initialization — `plxt lint`, `plxt fmt`, and `plxt config which` no longer require network/proxy access on startup
+- Make schema HTTP client lazy: `Schemas` and `SchemaAssociations` now accept `Option<reqwest::Client>` and only build the client when lint actually encounters `http://` or `https://` schema sources
+- Normal `.mthds` linting uses the builtin `pipelex://mthds.schema.json` schema without touching the network
+
 ## [0.6.2] - 2026-04-06
 
 ### Changed

--- a/crates/taplo-cli/src/commands/lint.rs
+++ b/crates/taplo-cli/src/commands/lint.rs
@@ -6,6 +6,7 @@ use codespan_reporting::files::SimpleFile;
 use serde_json::json;
 use taplo::parser;
 use taplo_common::{
+    config::{Config, SchemaOptions},
     environment::Environment,
     schema::associations::{AssociationRule, SchemaAssociation, DEFAULT_CATALOGS},
 };
@@ -14,7 +15,7 @@ use url::Url;
 
 impl<E: Environment> Taplo<E> {
     pub async fn execute_lint(&mut self, cmd: LintCommand) -> Result<(), anyhow::Error> {
-        self.schemas
+        self.schemas()?
             .cache()
             .set_cache_path(cmd.general.cache_path.clone());
 
@@ -22,7 +23,10 @@ impl<E: Environment> Taplo<E> {
 
         if !cmd.no_schema {
             if let Some(schema_url) = cmd.schema.clone() {
-                self.schemas.associations().add(
+                if url_needs_http(&schema_url) {
+                    self.schemas_with_http()?;
+                }
+                self.schemas()?.associations().add(
                     AssociationRule::regex(".*")?,
                     SchemaAssociation {
                         meta: json!({"source": "command-line"}),
@@ -32,10 +36,13 @@ impl<E: Environment> Taplo<E> {
                     },
                 );
             } else {
-                self.schemas.associations().add_from_config(&config);
+                if config_needs_http(&config) {
+                    self.schemas_with_http()?;
+                }
+                self.schemas()?.associations().add_from_config(&config);
 
                 for catalog in &cmd.schema_catalog {
-                    self.schemas
+                    self.schemas_with_http()?
                         .associations()
                         .add_from_catalog(catalog)
                         .await
@@ -44,7 +51,7 @@ impl<E: Environment> Taplo<E> {
 
                 if cmd.default_schema_catalogs {
                     for catalog in DEFAULT_CATALOGS {
-                        self.schemas
+                        self.schemas_with_http()?
                             .associations()
                             .add_from_catalog(&Url::parse(catalog).unwrap())
                             .await
@@ -62,7 +69,7 @@ impl<E: Environment> Taplo<E> {
     }
 
     #[tracing::instrument(skip_all)]
-    async fn lint_stdin(&self, _cmd: LintCommand) -> Result<(), anyhow::Error> {
+    async fn lint_stdin(&mut self, _cmd: LintCommand) -> Result<(), anyhow::Error> {
         let mut source = String::new();
         self.env.stdin().read_to_string(&mut source).await?;
         let cwd = self
@@ -104,7 +111,7 @@ impl<E: Environment> Taplo<E> {
         result
     }
 
-    async fn lint_file(&self, file: &Path, cwd: &Path) -> Result<(), anyhow::Error> {
+    async fn lint_file(&mut self, file: &Path, cwd: &Path) -> Result<(), anyhow::Error> {
         let source = self.env.read_file(file).await?;
         let source = String::from_utf8(source)?;
         self.lint_source(&file.to_string_lossy(), &source, cwd)
@@ -112,7 +119,7 @@ impl<E: Environment> Taplo<E> {
     }
 
     async fn lint_source(
-        &self,
+        &mut self,
         file_path: &str,
         source: &str,
         cwd: &Path,
@@ -153,11 +160,17 @@ impl<E: Environment> Taplo<E> {
 
         let file_uri: Url = format!("file://{file_path}").parse().unwrap();
 
-        self.schemas
+        self.schemas()?
             .associations()
             .add_from_document(&file_uri, &dom);
 
-        if let Some(schema_association) = self.schemas.associations().association_for(&file_uri) {
+        if let Some(schema_association) = self.schemas()?.associations().association_for(&file_uri)
+        {
+            if url_needs_http(&schema_association.url)
+                || schema_association.fallback_urls.iter().any(url_needs_http)
+            {
+                self.schemas_with_http()?;
+            }
             tracing::debug!(
                 schema.url = %schema_association.url,
                 schema.name = schema_association.meta["name"].as_str().unwrap_or(""),
@@ -168,7 +181,11 @@ impl<E: Environment> Taplo<E> {
             let schema_url = if schema_association.fallback_urls.is_empty() {
                 schema_association.url.clone()
             } else {
-                match self.schemas.resolve_association(&schema_association).await {
+                match self
+                    .schemas()?
+                    .resolve_association(&schema_association)
+                    .await
+                {
                     Ok((url, _)) => url,
                     Err(error) => {
                         return Err(error.context("schema waterfall resolution failed"));
@@ -176,7 +193,7 @@ impl<E: Environment> Taplo<E> {
                 }
             };
 
-            let errors = self.schemas.validate_root(&schema_url, &dom).await?;
+            let errors = self.schemas()?.validate_root(&schema_url, &dom).await?;
 
             if !errors.is_empty() {
                 if !self.compact {
@@ -193,4 +210,30 @@ impl<E: Environment> Taplo<E> {
 
         Ok(())
     }
+}
+
+fn url_needs_http(url: &Url) -> bool {
+    matches!(url.scheme(), "http" | "https")
+}
+
+fn schema_options_need_http(schema_opts: &SchemaOptions) -> bool {
+    schema_opts
+        .resolved_sources
+        .as_ref()
+        .is_some_and(|sources| sources.iter().any(url_needs_http))
+        || schema_opts.url.as_ref().is_some_and(url_needs_http)
+}
+
+fn config_needs_http(config: &Config) -> bool {
+    config
+        .global_options
+        .schema
+        .as_ref()
+        .is_some_and(schema_options_need_http)
+        || config.rule.iter().any(|rule| {
+            rule.options
+                .schema
+                .as_ref()
+                .is_some_and(schema_options_need_http)
+        })
 }

--- a/crates/taplo-cli/src/commands/lsp.rs
+++ b/crates/taplo-cli/src/commands/lsp.rs
@@ -7,10 +7,6 @@ use crate::{
 
 impl<E: Environment> Taplo<E> {
     pub async fn execute_lsp(&mut self, cmd: LspCommand) -> Result<(), anyhow::Error> {
-        self.schemas
-            .cache()
-            .set_cache_path(cmd.general.cache_path.clone());
-
         let config = self.load_config(&cmd.general).await?;
 
         let server = taplo_lsp::create_server();

--- a/crates/taplo-cli/src/lib.rs
+++ b/crates/taplo-cli/src/lib.rs
@@ -21,7 +21,7 @@ pub struct Taplo<E: Environment> {
     /// Default: false (preserves upstream taplo behavior). Set to true by plxt CLI.
     compact: bool,
     #[cfg(feature = "lint")]
-    schemas: Schemas<E>,
+    schemas: Option<Schemas<E>>,
     config: Option<Arc<Config>>,
 }
 
@@ -32,21 +32,41 @@ impl<E: Environment> Taplo<E> {
     }
 
     pub fn new(env: E) -> Self {
-        #[cfg(all(not(target_arch = "wasm32"), feature = "lint"))]
-        let http =
-            taplo_common::util::get_reqwest_client(std::time::Duration::from_secs(5)).unwrap();
-
-        #[cfg(all(target_arch = "wasm32", feature = "lint"))]
-        let http = reqwest::Client::default();
-
         Self {
             #[cfg(feature = "lint")]
-            schemas: Schemas::new(env.clone(), http),
+            schemas: None,
             colors: env.atty_stderr(),
             compact: false,
             config: None,
             env,
         }
+    }
+
+    #[cfg(feature = "lint")]
+    fn schemas(&mut self) -> Result<&mut Schemas<E>, anyhow::Error> {
+        if self.schemas.is_none() {
+            self.schemas = Some(Schemas::new(self.env.clone(), None));
+        }
+
+        Ok(self.schemas.as_mut().expect("schemas initialized"))
+    }
+
+    #[cfg(feature = "lint")]
+    fn schemas_with_http(&mut self) -> Result<&mut Schemas<E>, anyhow::Error> {
+        let schemas = self.schemas()?;
+
+        if !schemas.has_http_client() {
+            #[cfg(not(target_arch = "wasm32"))]
+            let http = taplo_common::util::get_reqwest_client(std::time::Duration::from_secs(5))
+                .context("failed to create schema HTTP client")?;
+
+            #[cfg(target_arch = "wasm32")]
+            let http = reqwest::Client::default();
+
+            schemas.set_http_client(http);
+        }
+
+        Ok(schemas)
     }
 
     #[tracing::instrument(skip_all)]

--- a/crates/taplo-common/src/schema/associations.rs
+++ b/crates/taplo-common/src/schema/associations.rs
@@ -43,14 +43,14 @@ pub mod source {
 #[derive(Clone)]
 pub struct SchemaAssociations<E: Environment> {
     concurrent_requests: Arc<Semaphore>,
-    http: reqwest::Client,
+    http: Option<reqwest::Client>,
     env: E,
     associations: Arc<RwLock<Vec<(AssociationRule, SchemaAssociation)>>>,
     cache: Cache<E>,
 }
 
 impl<E: Environment> SchemaAssociations<E> {
-    pub(crate) fn new(env: E, cache: Cache<E>, http: reqwest::Client) -> Self {
+    pub(crate) fn new(env: E, cache: Cache<E>, http: Option<reqwest::Client>) -> Self {
         let this = Self {
             concurrent_requests: Arc::new(Semaphore::new(10)),
             cache,
@@ -80,6 +80,10 @@ impl<E: Environment> SchemaAssociations<E> {
     /// even built-in ones that will have to be added again.
     pub fn clear(&self) {
         self.associations.write().clear();
+    }
+
+    pub fn set_http_client(&mut self, http: reqwest::Client) {
+        self.http = Some(http);
     }
 
     pub fn add_builtins(&self) {
@@ -361,13 +365,13 @@ impl<E: Environment> SchemaAssociations<E> {
     async fn fetch_external(&self, index_url: &Url) -> Result<SchemaCatalog, anyhow::Error> {
         let _permit = self.concurrent_requests.acquire().await?;
         match index_url.scheme() {
-            "http" | "https" => Ok(self
-                .http
-                .get(index_url.clone())
-                .send()
-                .await?
-                .json()
-                .await?),
+            "http" | "https" => {
+                let http = self
+                    .http
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("HTTP schema catalog fetching is not enabled"))?;
+                Ok(http.get(index_url.clone()).send().await?.json().await?)
+            }
             "file" => Ok(serde_json::from_slice(
                 &self
                     .env

--- a/crates/taplo-common/src/schema/mod.rs
+++ b/crates/taplo-common/src/schema/mod.rs
@@ -65,13 +65,13 @@ pub struct Schemas<E: Environment> {
     env: E,
     associations: SchemaAssociations<E>,
     concurrent_requests: Arc<Semaphore>,
-    http: reqwest::Client,
+    http: Option<reqwest::Client>,
     validators: Arc<Mutex<LruCache<Url, Arc<JSONSchema>>>>,
     cache: Cache<E>,
 }
 
 impl<E: Environment> Schemas<E> {
-    pub fn new(env: E, http: reqwest::Client) -> Self {
+    pub fn new(env: E, http: Option<reqwest::Client>) -> Self {
         let cache = Cache::new(env.clone());
 
         Self {
@@ -99,6 +99,15 @@ impl<E: Environment> Schemas<E> {
 
     pub fn env(&self) -> &E {
         &self.env
+    }
+
+    pub fn has_http_client(&self) -> bool {
+        self.http.is_some()
+    }
+
+    pub fn set_http_client(&mut self, http: reqwest::Client) {
+        self.http = Some(http.clone());
+        self.associations.set_http_client(http);
     }
 
     /// Clear all in-memory schema caches (LRU cache and compiled validators).
@@ -738,13 +747,13 @@ impl<E: Environment> Schemas<E> {
     async fn fetch_external(&self, schema_url: &Url) -> Result<Value, anyhow::Error> {
         let _permit = self.concurrent_requests.acquire().await?;
         match schema_url.scheme() {
-            "http" | "https" => Ok(self
-                .http
-                .get(schema_url.clone())
-                .send()
-                .await?
-                .json()
-                .await?),
+            "http" | "https" => {
+                let http = self
+                    .http
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("HTTP schema fetching is not enabled"))?;
+                Ok(http.get(schema_url.clone()).send().await?.json().await?)
+            }
             "file" => Ok(serde_json::from_slice(
                 &self
                     .env
@@ -1585,7 +1594,7 @@ mod tests {
         files.insert(PathBuf::from("/schemas/good.json"), minimal_schema_json());
         let env = MockEnv { files };
         let http = reqwest::Client::new();
-        let schemas = super::Schemas::new(env, http);
+        let schemas = super::Schemas::new(env, Some(http));
 
         let assoc = SchemaAssociation {
             url: "file:///schemas/good.json".parse().unwrap(),
@@ -1604,7 +1613,7 @@ mod tests {
             files: std::collections::HashMap::new(),
         };
         let http = reqwest::Client::new();
-        let schemas = super::Schemas::new(env, http);
+        let schemas = super::Schemas::new(env, Some(http));
 
         let assoc = SchemaAssociation {
             url: "file:///schemas/missing.json".parse().unwrap(),
@@ -1626,7 +1635,7 @@ mod tests {
         );
         let env = MockEnv { files };
         let http = reqwest::Client::new();
-        let schemas = super::Schemas::new(env, http);
+        let schemas = super::Schemas::new(env, Some(http));
 
         let assoc = SchemaAssociation {
             url: "file:///schemas/missing.json".parse().unwrap(),
@@ -1646,7 +1655,7 @@ mod tests {
         files.insert(PathBuf::from("/schemas/second.json"), minimal_schema_json());
         let env = MockEnv { files };
         let http = reqwest::Client::new();
-        let schemas = super::Schemas::new(env, http);
+        let schemas = super::Schemas::new(env, Some(http));
 
         let assoc = SchemaAssociation {
             url: "file:///schemas/first.json".parse().unwrap(),
@@ -1666,7 +1675,7 @@ mod tests {
             files: std::collections::HashMap::new(),
         };
         let http = reqwest::Client::new();
-        let schemas = super::Schemas::new(env, http);
+        let schemas = super::Schemas::new(env, Some(http));
 
         let assoc = SchemaAssociation {
             url: "file:///schemas/a.json".parse().unwrap(),
@@ -1689,7 +1698,7 @@ mod tests {
             files: std::collections::HashMap::new(),
         };
         let http = reqwest::Client::new();
-        let schemas = super::Schemas::new(env, http);
+        let schemas = super::Schemas::new(env, Some(http));
 
         // The actual bundle.mthds content from pipelex-demo
         let mthds_content = r#"

--- a/crates/taplo-lsp/src/world.rs
+++ b/crates/taplo-lsp/src/world.rs
@@ -131,7 +131,7 @@ impl<E: Environment> WorkspaceState<E> {
             root,
             documents: Default::default(),
             taplo_config: Default::default(),
-            schemas: Schemas::new(env, client),
+            schemas: Schemas::new(env, Some(client)),
             config: LspConfig::default(),
         }
     }


### PR DESCRIPTION
The problem was that plxt created its reqwest HTTP client too eagerly. In practice, even purely local commands like plxt config which, plxt fmt, and normal .mthds lint would initialize the shared schema system up
  front. On macOS inside the Codex sandbox, reqwest's proxy/system-network discovery goes through SystemConfiguration.framework, and that path panicked before command-specific logic ran. The key point is that norm
  al .mthds lint does not actually need any remote schema fetch, because the MTHDS schema is embedded in the binary as the builtin pipelex://mthds.schema.json.

  The first fix was to stop constructing the schema HTTP client during CLI startup. We made Taplo initialize Schemas lazily instead of unconditionally in Taplo::new(). That removed the crash for commands that never
  need schemas at all, like config which. But it did not fully solve the hook, because plxt lint still instantiated Schemas, and that still pulled in the reqwest client.

  The real fix was to separate local schema use from remote schema capability. We changed Schemas and SchemaAssociations to support Option<reqwest::Client> instead of always requiring a concrete client. With that
  change, local-only schema operations can run with no HTTP client at all. Then we updated the lint path so it stays local by default and only upgrades to an HTTP-enabled client if lint actually encounters an
  http:// or https:// schema source, such as --schema, --schema-catalog, default online catalogs, or config-driven remote schema URLs. For ordinary .mthds files using the builtin schema, no HTTP client is built, so
  the Codex sandbox never hits the macOS proxy-discovery panic path.

  We validated the change by rebuilding pipelex-cli locally and testing the patched plxt in the same sandboxed environment that previously failed. After the patch, direct sandboxed plxt lint --quiet <bundle>.mthds
  succeeded, and the Codex stop hook also passed once we made it use the locally built plxt. In short: we preserved remote schema support, but made it conditional on actual remote use instead of ambient CLI startup
  behavior.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make schema HTTP client initialization lazy to prevent crashes in sandboxed or offline environments. Network access now happens only when `http(s)` schemas or catalogs are actually used.

- **Bug Fixes**
  - `plxt lint`, `plxt fmt`, and `plxt config which` no longer require network/proxy on startup; `.mthds` linting uses the builtin `pipelex://mthds.schema.json` schema.
  - Avoid eager `reqwest::Client` creation; enable HTTP only when a config or association references `http(s)` sources.

- **Refactors**
  - `Schemas` and `SchemaAssociations` accept `Option<reqwest::Client>` with `set_http_client`/`has_http_client`; fetchers error if HTTP isn’t enabled.
  - CLI detects when HTTP is needed from config/URLs and enables it on demand; LSP updated to pass `Some(client)`.

<sup>Written for commit 4a1f5e0ee35310d59a3acefc3c7fde04a37cb0f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

