### PR TITLE
Release v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Pipelex IDE Extension and `plxt` CLI Changelog
 
+## [Unreleased]
+
+### Fixed
+- Fix `plxt` crashing in sandboxed environments (Codex, CI containers) due to eager HTTP client initialization — `plxt lint`, `plxt fmt`, and `plxt config which` no longer require network/proxy access on startup
+- Make schema HTTP client lazy: `Schemas` and `SchemaAssociations` now accept `Option<reqwest::Client>` and only build the client when lint actually encounters `http://` or `https://` schema sources
+- Normal `.mthds` linting uses the builtin `pipelex://mthds.schema.json` schema without touching the network
+
 ## [0.6.2] - 2026-04-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Pipelex IDE Extension and `plxt` CLI Changelog
 
-## [Unreleased]
+## [0.6.3] - 2026-04-13
 
 ### Fixed
-- Fix `plxt` crashing in sandboxed environments (Codex, CI containers) due to eager HTTP client initialization — `plxt lint`, `plxt fmt`, and `plxt config which` no longer require network/proxy access on startup
-- Make schema HTTP client lazy: `Schemas` and `SchemaAssociations` now accept `Option<reqwest::Client>` and only build the client when lint actually encounters `http://` or `https://` schema sources
-- Normal `.mthds` linting uses the builtin `pipelex://mthds.schema.json` schema without touching the network
+- Fix `plxt` crashing in sandboxed environments (Codex, CI containers) due to eager HTTP client initialization — `plxt lint`, `plxt fmt`, and `plxt config which` no longer require network/proxy access on startup (plxt 0.3.3)
+- Make schema HTTP client lazy: `Schemas` and `SchemaAssociations` now accept `Option<reqwest::Client>` and only build the client when lint actually encounters `http://` or `https://` schema sources (plxt 0.3.3)
+- Normal `.mthds` linting uses the builtin `pipelex://mthds.schema.json` schema without touching the network (plxt 0.3.3)
 
 ## [0.6.2] - 2026-04-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,7 +1574,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipelex-cli"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-ctrlc",

--- a/crates/pipelex-cli/Cargo.toml
+++ b/crates/pipelex-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "pipelex-cli"
 description  = "Pipelex Tools CLI (plxt) - wraps taplo-cli with MTHDS support"
-version      = "0.3.2"
+version      = "0.3.3"
 rust-version = { workspace = true }
 authors      = { workspace = true }
 edition      = { workspace = true }

--- a/crates/taplo-cli/src/commands/lint.rs
+++ b/crates/taplo-cli/src/commands/lint.rs
@@ -6,6 +6,7 @@ use codespan_reporting::files::SimpleFile;
 use serde_json::json;
 use taplo::parser;
 use taplo_common::{
+    config::{Config, SchemaOptions},
     environment::Environment,
     schema::associations::{AssociationRule, SchemaAssociation, DEFAULT_CATALOGS},
 };
@@ -14,7 +15,7 @@ use url::Url;
 
 impl<E: Environment> Taplo<E> {
     pub async fn execute_lint(&mut self, cmd: LintCommand) -> Result<(), anyhow::Error> {
-        self.schemas
+        self.schemas()?
             .cache()
             .set_cache_path(cmd.general.cache_path.clone());
 
@@ -22,7 +23,10 @@ impl<E: Environment> Taplo<E> {
 
         if !cmd.no_schema {
             if let Some(schema_url) = cmd.schema.clone() {
-                self.schemas.associations().add(
+                if url_needs_http(&schema_url) {
+                    self.schemas_with_http()?;
+                }
+                self.schemas()?.associations().add(
                     AssociationRule::regex(".*")?,
                     SchemaAssociation {
                         meta: json!({"source": "command-line"}),
@@ -32,10 +36,13 @@ impl<E: Environment> Taplo<E> {
                     },
                 );
             } else {
-                self.schemas.associations().add_from_config(&config);
+                if config_needs_http(&config) {
+                    self.schemas_with_http()?;
+                }
+                self.schemas()?.associations().add_from_config(&config);
 
                 for catalog in &cmd.schema_catalog {
-                    self.schemas
+                    self.schemas_with_http()?
                         .associations()
                         .add_from_catalog(catalog)
                         .await
@@ -44,7 +51,7 @@ impl<E: Environment> Taplo<E> {
 
                 if cmd.default_schema_catalogs {
                     for catalog in DEFAULT_CATALOGS {
-                        self.schemas
+                        self.schemas_with_http()?
                             .associations()
                             .add_from_catalog(&Url::parse(catalog).unwrap())
                             .await
@@ -62,7 +69,7 @@ impl<E: Environment> Taplo<E> {
     }
 
     #[tracing::instrument(skip_all)]
-    async fn lint_stdin(&self, _cmd: LintCommand) -> Result<(), anyhow::Error> {
+    async fn lint_stdin(&mut self, _cmd: LintCommand) -> Result<(), anyhow::Error> {
         let mut source = String::new();
         self.env.stdin().read_to_string(&mut source).await?;
         let cwd = self
@@ -104,7 +111,7 @@ impl<E: Environment> Taplo<E> {
         result
     }
 
-    async fn lint_file(&self, file: &Path, cwd: &Path) -> Result<(), anyhow::Error> {
+    async fn lint_file(&mut self, file: &Path, cwd: &Path) -> Result<(), anyhow::Error> {
         let source = self.env.read_file(file).await?;
         let source = String::from_utf8(source)?;
         self.lint_source(&file.to_string_lossy(), &source, cwd)
@@ -112,7 +119,7 @@ impl<E: Environment> Taplo<E> {
     }
 
     async fn lint_source(
-        &self,
+        &mut self,
         file_path: &str,
         source: &str,
         cwd: &Path,
@@ -153,11 +160,17 @@ impl<E: Environment> Taplo<E> {
 
         let file_uri: Url = format!("file://{file_path}").parse().unwrap();
 
-        self.schemas
+        self.schemas()?
             .associations()
             .add_from_document(&file_uri, &dom);
 
-        if let Some(schema_association) = self.schemas.associations().association_for(&file_uri) {
+        if let Some(schema_association) = self.schemas()?.associations().association_for(&file_uri)
+        {
+            if url_needs_http(&schema_association.url)
+                || schema_association.fallback_urls.iter().any(url_needs_http)
+            {
+                self.schemas_with_http()?;
+            }
             tracing::debug!(
                 schema.url = %schema_association.url,
                 schema.name = schema_association.meta["name"].as_str().unwrap_or(""),
@@ -168,7 +181,11 @@ impl<E: Environment> Taplo<E> {
             let schema_url = if schema_association.fallback_urls.is_empty() {
                 schema_association.url.clone()
             } else {
-                match self.schemas.resolve_association(&schema_association).await {
+                match self
+                    .schemas()?
+                    .resolve_association(&schema_association)
+                    .await
+                {
                     Ok((url, _)) => url,
                     Err(error) => {
                         return Err(error.context("schema waterfall resolution failed"));
@@ -176,7 +193,7 @@ impl<E: Environment> Taplo<E> {
                 }
             };
 
-            let errors = self.schemas.validate_root(&schema_url, &dom).await?;
+            let errors = self.schemas()?.validate_root(&schema_url, &dom).await?;
 
             if !errors.is_empty() {
                 if !self.compact {
@@ -193,4 +210,30 @@ impl<E: Environment> Taplo<E> {
 
         Ok(())
     }
+}
+
+fn url_needs_http(url: &Url) -> bool {
+    matches!(url.scheme(), "http" | "https")
+}
+
+fn schema_options_need_http(schema_opts: &SchemaOptions) -> bool {
+    schema_opts
+        .resolved_sources
+        .as_ref()
+        .is_some_and(|sources| sources.iter().any(url_needs_http))
+        || schema_opts.url.as_ref().is_some_and(url_needs_http)
+}
+
+fn config_needs_http(config: &Config) -> bool {
+    config
+        .global_options
+        .schema
+        .as_ref()
+        .is_some_and(schema_options_need_http)
+        || config.rule.iter().any(|rule| {
+            rule.options
+                .schema
+                .as_ref()
+                .is_some_and(schema_options_need_http)
+        })
 }

--- a/crates/taplo-cli/src/commands/lint.rs
+++ b/crates/taplo-cli/src/commands/lint.rs
@@ -169,6 +169,7 @@ impl<E: Environment> Taplo<E> {
             if url_needs_http(&schema_association.url)
                 || schema_association.fallback_urls.iter().any(url_needs_http)
             {
+                // Ensure HTTP client is ready before resolve/validate below
                 self.schemas_with_http()?;
             }
             tracing::debug!(

--- a/crates/taplo-cli/src/commands/lsp.rs
+++ b/crates/taplo-cli/src/commands/lsp.rs
@@ -7,10 +7,6 @@ use crate::{
 
 impl<E: Environment> Taplo<E> {
     pub async fn execute_lsp(&mut self, cmd: LspCommand) -> Result<(), anyhow::Error> {
-        self.schemas
-            .cache()
-            .set_cache_path(cmd.general.cache_path.clone());
-
         let config = self.load_config(&cmd.general).await?;
 
         let server = taplo_lsp::create_server();

--- a/crates/taplo-cli/src/lib.rs
+++ b/crates/taplo-cli/src/lib.rs
@@ -21,7 +21,7 @@ pub struct Taplo<E: Environment> {
     /// Default: false (preserves upstream taplo behavior). Set to true by plxt CLI.
     compact: bool,
     #[cfg(feature = "lint")]
-    schemas: Schemas<E>,
+    schemas: Option<Schemas<E>>,
     config: Option<Arc<Config>>,
 }
 
@@ -32,21 +32,41 @@ impl<E: Environment> Taplo<E> {
     }
 
     pub fn new(env: E) -> Self {
-        #[cfg(all(not(target_arch = "wasm32"), feature = "lint"))]
-        let http =
-            taplo_common::util::get_reqwest_client(std::time::Duration::from_secs(5)).unwrap();
-
-        #[cfg(all(target_arch = "wasm32", feature = "lint"))]
-        let http = reqwest::Client::default();
-
         Self {
             #[cfg(feature = "lint")]
-            schemas: Schemas::new(env.clone(), http),
+            schemas: None,
             colors: env.atty_stderr(),
             compact: false,
             config: None,
             env,
         }
+    }
+
+    #[cfg(feature = "lint")]
+    fn schemas(&mut self) -> Result<&mut Schemas<E>, anyhow::Error> {
+        if self.schemas.is_none() {
+            self.schemas = Some(Schemas::new(self.env.clone(), None));
+        }
+
+        Ok(self.schemas.as_mut().expect("schemas initialized"))
+    }
+
+    #[cfg(feature = "lint")]
+    fn schemas_with_http(&mut self) -> Result<&mut Schemas<E>, anyhow::Error> {
+        let schemas = self.schemas()?;
+
+        if !schemas.has_http_client() {
+            #[cfg(not(target_arch = "wasm32"))]
+            let http = taplo_common::util::get_reqwest_client(std::time::Duration::from_secs(5))
+                .context("failed to create schema HTTP client")?;
+
+            #[cfg(target_arch = "wasm32")]
+            let http = reqwest::Client::default();
+
+            schemas.set_http_client(http);
+        }
+
+        Ok(schemas)
     }
 
     #[tracing::instrument(skip_all)]

--- a/crates/taplo-common/src/schema/associations.rs
+++ b/crates/taplo-common/src/schema/associations.rs
@@ -43,14 +43,14 @@ pub mod source {
 #[derive(Clone)]
 pub struct SchemaAssociations<E: Environment> {
     concurrent_requests: Arc<Semaphore>,
-    http: reqwest::Client,
+    http: Option<reqwest::Client>,
     env: E,
     associations: Arc<RwLock<Vec<(AssociationRule, SchemaAssociation)>>>,
     cache: Cache<E>,
 }
 
 impl<E: Environment> SchemaAssociations<E> {
-    pub(crate) fn new(env: E, cache: Cache<E>, http: reqwest::Client) -> Self {
+    pub(crate) fn new(env: E, cache: Cache<E>, http: Option<reqwest::Client>) -> Self {
         let this = Self {
             concurrent_requests: Arc::new(Semaphore::new(10)),
             cache,
@@ -80,6 +80,10 @@ impl<E: Environment> SchemaAssociations<E> {
     /// even built-in ones that will have to be added again.
     pub fn clear(&self) {
         self.associations.write().clear();
+    }
+
+    pub fn set_http_client(&mut self, http: reqwest::Client) {
+        self.http = Some(http);
     }
 
     pub fn add_builtins(&self) {
@@ -361,13 +365,13 @@ impl<E: Environment> SchemaAssociations<E> {
     async fn fetch_external(&self, index_url: &Url) -> Result<SchemaCatalog, anyhow::Error> {
         let _permit = self.concurrent_requests.acquire().await?;
         match index_url.scheme() {
-            "http" | "https" => Ok(self
-                .http
-                .get(index_url.clone())
-                .send()
-                .await?
-                .json()
-                .await?),
+            "http" | "https" => {
+                let http = self
+                    .http
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("HTTP schema catalog fetching is not enabled"))?;
+                Ok(http.get(index_url.clone()).send().await?.json().await?)
+            }
             "file" => Ok(serde_json::from_slice(
                 &self
                     .env

--- a/crates/taplo-common/src/schema/mod.rs
+++ b/crates/taplo-common/src/schema/mod.rs
@@ -106,8 +106,8 @@ impl<E: Environment> Schemas<E> {
     }
 
     pub fn set_http_client(&mut self, http: reqwest::Client) {
-        self.http = Some(http.clone());
-        self.associations.set_http_client(http);
+        self.associations.set_http_client(http.clone());
+        self.http = Some(http);
     }
 
     /// Clear all in-memory schema caches (LRU cache and compiled validators).

--- a/crates/taplo-common/src/schema/mod.rs
+++ b/crates/taplo-common/src/schema/mod.rs
@@ -65,13 +65,13 @@ pub struct Schemas<E: Environment> {
     env: E,
     associations: SchemaAssociations<E>,
     concurrent_requests: Arc<Semaphore>,
-    http: reqwest::Client,
+    http: Option<reqwest::Client>,
     validators: Arc<Mutex<LruCache<Url, Arc<JSONSchema>>>>,
     cache: Cache<E>,
 }
 
 impl<E: Environment> Schemas<E> {
-    pub fn new(env: E, http: reqwest::Client) -> Self {
+    pub fn new(env: E, http: Option<reqwest::Client>) -> Self {
         let cache = Cache::new(env.clone());
 
         Self {
@@ -99,6 +99,15 @@ impl<E: Environment> Schemas<E> {
 
     pub fn env(&self) -> &E {
         &self.env
+    }
+
+    pub fn has_http_client(&self) -> bool {
+        self.http.is_some()
+    }
+
+    pub fn set_http_client(&mut self, http: reqwest::Client) {
+        self.http = Some(http.clone());
+        self.associations.set_http_client(http);
     }
 
     /// Clear all in-memory schema caches (LRU cache and compiled validators).
@@ -738,13 +747,13 @@ impl<E: Environment> Schemas<E> {
     async fn fetch_external(&self, schema_url: &Url) -> Result<Value, anyhow::Error> {
         let _permit = self.concurrent_requests.acquire().await?;
         match schema_url.scheme() {
-            "http" | "https" => Ok(self
-                .http
-                .get(schema_url.clone())
-                .send()
-                .await?
-                .json()
-                .await?),
+            "http" | "https" => {
+                let http = self
+                    .http
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("HTTP schema fetching is not enabled"))?;
+                Ok(http.get(schema_url.clone()).send().await?.json().await?)
+            }
             "file" => Ok(serde_json::from_slice(
                 &self
                     .env
@@ -1585,7 +1594,7 @@ mod tests {
         files.insert(PathBuf::from("/schemas/good.json"), minimal_schema_json());
         let env = MockEnv { files };
         let http = reqwest::Client::new();
-        let schemas = super::Schemas::new(env, http);
+        let schemas = super::Schemas::new(env, Some(http));
 
         let assoc = SchemaAssociation {
             url: "file:///schemas/good.json".parse().unwrap(),
@@ -1604,7 +1613,7 @@ mod tests {
             files: std::collections::HashMap::new(),
         };
         let http = reqwest::Client::new();
-        let schemas = super::Schemas::new(env, http);
+        let schemas = super::Schemas::new(env, Some(http));
 
         let assoc = SchemaAssociation {
             url: "file:///schemas/missing.json".parse().unwrap(),
@@ -1626,7 +1635,7 @@ mod tests {
         );
         let env = MockEnv { files };
         let http = reqwest::Client::new();
-        let schemas = super::Schemas::new(env, http);
+        let schemas = super::Schemas::new(env, Some(http));
 
         let assoc = SchemaAssociation {
             url: "file:///schemas/missing.json".parse().unwrap(),
@@ -1646,7 +1655,7 @@ mod tests {
         files.insert(PathBuf::from("/schemas/second.json"), minimal_schema_json());
         let env = MockEnv { files };
         let http = reqwest::Client::new();
-        let schemas = super::Schemas::new(env, http);
+        let schemas = super::Schemas::new(env, Some(http));
 
         let assoc = SchemaAssociation {
             url: "file:///schemas/first.json".parse().unwrap(),
@@ -1666,7 +1675,7 @@ mod tests {
             files: std::collections::HashMap::new(),
         };
         let http = reqwest::Client::new();
-        let schemas = super::Schemas::new(env, http);
+        let schemas = super::Schemas::new(env, Some(http));
 
         let assoc = SchemaAssociation {
             url: "file:///schemas/a.json".parse().unwrap(),
@@ -1689,7 +1698,7 @@ mod tests {
             files: std::collections::HashMap::new(),
         };
         let http = reqwest::Client::new();
-        let schemas = super::Schemas::new(env, http);
+        let schemas = super::Schemas::new(env, Some(http));
 
         // The actual bundle.mthds content from pipelex-demo
         let mthds_content = r#"

--- a/crates/taplo-lsp/src/world.rs
+++ b/crates/taplo-lsp/src/world.rs
@@ -131,7 +131,7 @@ impl<E: Environment> WorkspaceState<E> {
             root,
             documents: Default::default(),
             taplo_config: Default::default(),
-            schemas: Schemas::new(env, client),
+            schemas: Schemas::new(env, Some(client)),
             config: LspConfig::default(),
         }
     }

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "pipelex",
   "displayName": "Pipelex",
   "description": "Pipelex extension for the MTHDS language",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "repository": {
     "url": "https://github.com/Pipelex/vscode-pipelex"
   },


### PR DESCRIPTION
## Summary
- Bump extension version 0.6.2 → 0.6.3
- Bump plxt CLI version 0.3.2 → 0.3.3
- Fix `plxt` crashing in sandboxed environments (Codex, CI) due to eager HTTP client initialization
- Make schema HTTP client lazy — only built when lint encounters remote schema sources

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `plxt` crashes in sandboxed environments by lazily creating the schema HTTP client so linting runs offline unless remote schemas/catalogs are used. Releases VS Code extension v0.6.3 and `plxt` v0.3.3.

- **Bug Fixes**
  - Create the schema HTTP client only when encountering `http`/`https` schema URLs or catalogs; no network/proxy needed at startup for `plxt lint`, `plxt fmt`, or `plxt config which`.
  - Default `.mthds` lint uses the builtin `pipelex://mthds.schema.json` schema, avoiding network access.

- **Refactors**
  - `Schemas` and `SchemaAssociations` now take `Option<reqwest::Client>` with `set_http_client`/`has_http_client`; HTTP fetches are gated and error clearly if not enabled.
  - `taplo-cli` lazily creates schemas and only enables HTTP when the provided schema URL/config requires it, including before catalog loads and fallback resolution.

<sup>Written for commit 2cd5e375a268e79a6703c2f83345ef79592d1efa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

