### PR TITLE
release: v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Pipelex IDE Extension and `plxt` CLI Changelog
 
+## [0.6.4] - 2026-04-15
+
+### Changed
+- Upgrade @pipelex/mthds-ui to v0.3.4
+
 ## [0.6.3] - 2026-04-13
 
 ### Fixed

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "pipelex",
   "displayName": "Pipelex",
   "description": "Pipelex extension for the MTHDS language",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "repository": {
     "url": "https://github.com/Pipelex/vscode-pipelex"
   },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -747,7 +747,7 @@
   },
   "dependencies": {
     "@pipelex/lsp": "portal:../../js/lsp",
-    "@pipelex/mthds-ui": "github:Pipelex/mthds-ui#9884169254aa82d7e6d576f99f83ba914a856490",
+    "@pipelex/mthds-ui": "github:Pipelex/mthds-ui#838c0a3e57c3e19cf9d9b5fea806ca915cb820d3",
     "deep-equal": "^2.2.3",
     "encoding": "^0.1.13",
     "fast-glob": "^3.3.2",

--- a/editors/vscode/yarn.lock
+++ b/editors/vscode/yarn.lock
@@ -483,9 +483,9 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@pipelex/mthds-ui@github:Pipelex/mthds-ui#9884169254aa82d7e6d576f99f83ba914a856490":
-  version: 0.2.2
-  resolution: "@pipelex/mthds-ui@https://github.com/Pipelex/mthds-ui.git#commit=9884169254aa82d7e6d576f99f83ba914a856490"
+"@pipelex/mthds-ui@github:Pipelex/mthds-ui#838c0a3e57c3e19cf9d9b5fea806ca915cb820d3":
+  version: 0.3.4
+  resolution: "@pipelex/mthds-ui@https://github.com/Pipelex/mthds-ui.git#commit=838c0a3e57c3e19cf9d9b5fea806ca915cb820d3"
   dependencies:
     "@xyflow/react": "npm:^12"
     dompurify: "npm:^3.3.3"
@@ -501,7 +501,7 @@ __metadata:
       optional: true
     shiki:
       optional: true
-  checksum: a02b28285445540c60aac8045c42dd1e01146d0f731795b123b5d947bebb6f82dfaf5f6f7fdc27dfebb266137a7274454452929fa6eecfe87d55fcc0bc61bf58
+  checksum: f6646c5846aa0c5e0daebfce7c3624b047a7a98ba359862f42968a42dfd2e5be4e66ffeac7a31d02a9bfb2af43c515f82975a3416aeb570f00e49da0bcdae8ac
   languageName: node
   linkType: hard
 
@@ -3471,7 +3471,7 @@ __metadata:
   resolution: "pipelex@workspace:."
   dependencies:
     "@pipelex/lsp": "portal:../../js/lsp"
-    "@pipelex/mthds-ui": "github:Pipelex/mthds-ui#9884169254aa82d7e6d576f99f83ba914a856490"
+    "@pipelex/mthds-ui": "github:Pipelex/mthds-ui#838c0a3e57c3e19cf9d9b5fea806ca915cb820d3"
     "@rollup/plugin-commonjs": "npm:^25.0.7"
     "@rollup/plugin-node-resolve": "npm:^15.2.3"
     "@rollup/plugin-replace": "npm:^5.0.5"


### PR DESCRIPTION
## Summary
- Bump extension to v0.6.4
- Upgrade @pipelex/mthds-ui to v0.3.4

## Test plan
- [ ] CI green
- [ ] Merge to main triggers auto-tag and publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.6.4 of the Pipelex VS Code extension. Updates `@pipelex/mthds-ui` to v0.3.4 to pull in the latest UI fixes and improvements.

- **Dependencies**
  - Bump `@pipelex/mthds-ui` to v0.3.4

<sup>Written for commit 2c6add61f064464e46bcef385233a4bb75915ada. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

