### PR TITLE
Release v0.6.5: fix PDF preview in Method Graph viewer

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if grep -qE 'mthds-ui.*(portal:|file:)' editors/vscode/package.json 2>/dev/null; then
-    echo "ERROR: Local mthds-ui link detected in editors/vscode/package.json."
-    echo "Run 'make use-github' before committing."
+if ! grep -qE '"@pipelex/mthds-ui":[[:space:]]*"npm:' editors/vscode/package.json 2>/dev/null; then
+    echo "ERROR: @pipelex/mthds-ui in editors/vscode/package.json is not the npm spec."
+    echo "Found:"
+    grep -nE '"@pipelex/mthds-ui":' editors/vscode/package.json || true
+    echo "Run 'make use-npm' before committing."
     exit 1
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Pipelex IDE Extension and `plxt` CLI Changelog
 
+## [0.6.5] - 2026-05-05
+
+### Fixed
+- PDFs in the Method Graph viewer now display a clickable "Open externally" tile instead of a blank `<embed>` frame when previewing live-run GraphSpecs that contain PDF stuff (e.g. presigned S3 URLs). VS Code webviews run in Electron without the Chromium PDFium plugin, so inline PDF rendering was never going to work; clicking the tile hands the URL to `vscode.env.openExternal` so the OS PDF viewer or default browser takes over
+
+### Changed
+- Upgrade @pipelex/mthds-ui to v0.5.1 — adds `canEmbedPdf` and `onOpenExternally` props on `StuffViewer`/`ConceptDetailPanel`/`GraphViewer` so hosts that can't render `<embed type="application/pdf">` can fall back to a clickable open-externally tile
+- Switch `@pipelex/mthds-ui` from GitHub-pinned to the npm registry; clean up the webview toolbar wiring on the way
+
 ## [0.6.4] - 2026-04-15
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ PYTHON_VERSION    ?= 3.13
 
 .PHONY: help sync-grammar s update-schema up
 .PHONY: build cli pipelex-tools env lock ext ext-deps ext-install ext-uninstall vsix clean test check check-no-local-deps fmt-check fmt lint plxt-lint docs setup-hooks
-.PHONY: use-github use-local ug ul pin-mthds-ui
+.PHONY: use-github use-local use-npm ug ul un pin-mthds-ui
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -143,18 +143,27 @@ update-schema: ## Download the latest MTHDS JSON Schema
 up: update-schema
 
 # --- Switch mthds-ui source ---
-# use-local: portal link to sibling ../mthds-ui for live development
-# use-github: install from GitHub to test the published version
+# use-local:  portal link to sibling ../mthds-ui for live development
+# use-github: revert package.json to the pinned GitHub spec at HEAD
+# use-npm:    install from the npm registry (latest by default, or VERSION=x.y.z)
 
 use-github: ## Switch back to pinned GitHub mthds-ui
 	cd $(EXT_DIR) && git checkout -- package.json yarn.lock && yarn install --immutable
-	@echo "Restored pinned GitHub mthds-ui. Run 'make use-local' to switch back."
+	@echo "Restored pinned GitHub mthds-ui. Run 'make use-local' or 'make use-npm' to switch back."
 
 use-local: setup-hooks ## Switch to local mthds-ui (portal link)
+	@if [ ! -d ../mthds-ui ]; then echo "ERROR: ../mthds-ui not found. Clone it next to vscode-pipelex."; exit 1; fi
+	cd ../mthds-ui && yarn install && yarn build
 	cd $(EXT_DIR) && yarn add @pipelex/mthds-ui@portal:../../../mthds-ui
 	@echo "Switched to local mthds-ui (portal link). Run 'make use-github' to switch back."
 
-pin-mthds-ui: ## Pin mthds-ui to a tag (default: latest). Usage: make pin-mthds-ui [TAG=v0.3.0]
+use-npm: ## Switch to @pipelex/mthds-ui from npm registry (default: latest). Usage: make use-npm [VERSION=0.5.0]
+	@VERSION="$${VERSION:-latest}" && \
+	echo "Installing @pipelex/mthds-ui@$$VERSION from npm" && \
+	cd $(EXT_DIR) && yarn add "@pipelex/mthds-ui@npm:$$VERSION" && \
+	echo "Switched to npm @pipelex/mthds-ui@$$VERSION. Review the diff, then commit package.json + yarn.lock."
+
+pin-mthds-ui: ## Pin mthds-ui to a GitHub tag (default: latest). Usage: make pin-mthds-ui [TAG=v0.3.0]
 	@if [ -n "$${TAG:-}" ]; then \
 		SHA=$$(gh api repos/Pipelex/mthds-ui/tags --jq ".[] | select(.name == \"$$TAG\") | .commit.sha") && \
 		if [ -z "$$SHA" ]; then echo "ERROR: Tag $$TAG not found in Pipelex/mthds-ui"; exit 1; fi; \
@@ -169,6 +178,7 @@ pin-mthds-ui: ## Pin mthds-ui to a tag (default: latest). Usage: make pin-mthds-
 
 ug: use-github
 ul: use-local
+un: use-npm
 pmu: pin-mthds-ui
 
 $(GRAMMAR_DST): $(GRAMMAR_SRC)

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ PYTHON_VERSION    ?= 3.13
 
 .PHONY: help sync-grammar s update-schema up
 .PHONY: build cli pipelex-tools env lock ext ext-deps ext-install ext-uninstall vsix clean test check check-no-local-deps fmt-check fmt lint plxt-lint docs setup-hooks
-.PHONY: use-github use-local use-npm ug ul un pin-mthds-ui
+.PHONY: use-local use-npm ul un pin-mthds-ui
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -111,9 +111,9 @@ test: ## Run all tests (Rust + VS Code extension)
 	cargo test -p taplo-lsp
 	cd $(EXT_DIR) && yarn test
 
-check-no-local-deps: ## Fail if a local mthds-ui link would be committed
-	@! grep -qE 'mthds-ui.*(portal:|file:)' $(EXT_DIR)/package.json || \
-		{ echo "ERROR: Local mthds-ui link in $(EXT_DIR)/package.json. Run 'make use-github' first."; exit 1; }
+check-no-local-deps: ## Fail if mthds-ui is not the npm spec
+	@grep -qE '"@pipelex/mthds-ui":[[:space:]]*"npm:' $(EXT_DIR)/package.json || \
+		{ echo "ERROR: @pipelex/mthds-ui in $(EXT_DIR)/package.json is not the npm spec. Run 'make use-npm' first."; exit 1; }
 
 setup-hooks: ## Configure git to use .githooks/ for hooks
 	@git config core.hooksPath .githooks
@@ -144,18 +144,13 @@ up: update-schema
 
 # --- Switch mthds-ui source ---
 # use-local:  portal link to sibling ../mthds-ui for live development
-# use-github: revert package.json to the pinned GitHub spec at HEAD
 # use-npm:    install from the npm registry (latest by default, or VERSION=x.y.z)
-
-use-github: ## Switch back to pinned GitHub mthds-ui
-	cd $(EXT_DIR) && git checkout -- package.json yarn.lock && yarn install --immutable
-	@echo "Restored pinned GitHub mthds-ui. Run 'make use-local' or 'make use-npm' to switch back."
 
 use-local: setup-hooks ## Switch to local mthds-ui (portal link)
 	@if [ ! -d ../mthds-ui ]; then echo "ERROR: ../mthds-ui not found. Clone it next to vscode-pipelex."; exit 1; fi
 	cd ../mthds-ui && yarn install && yarn build
 	cd $(EXT_DIR) && yarn add @pipelex/mthds-ui@portal:../../../mthds-ui
-	@echo "Switched to local mthds-ui (portal link). Run 'make use-github' to switch back."
+	@echo "Switched to local mthds-ui (portal link). Run 'make use-npm' to switch back."
 
 use-npm: ## Switch to @pipelex/mthds-ui from npm registry (default: latest). Usage: make use-npm [VERSION=0.5.0]
 	@VERSION="$${VERSION:-latest}" && \
@@ -176,7 +171,6 @@ pin-mthds-ui: ## Pin mthds-ui to a GitHub tag (default: latest). Usage: make pin
 	cd $(EXT_DIR) && yarn add "@pipelex/mthds-ui@github:Pipelex/mthds-ui#$$SHA" && \
 	echo "Done. Review the diff, then commit package.json + yarn.lock."
 
-ug: use-github
 ul: use-local
 un: use-npm
 pmu: pin-mthds-ui

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ PYTHON_VERSION    ?= 3.13
 
 .PHONY: help sync-grammar s update-schema up
 .PHONY: build cli pipelex-tools env lock ext ext-deps ext-install ext-uninstall vsix clean test check check-no-local-deps fmt-check fmt lint plxt-lint docs setup-hooks
-.PHONY: use-local use-npm ul un pin-mthds-ui
+.PHONY: use-local use-npm ul un
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -158,22 +158,8 @@ use-npm: ## Switch to @pipelex/mthds-ui from npm registry (default: latest). Usa
 	cd $(EXT_DIR) && yarn add "@pipelex/mthds-ui@npm:$$VERSION" && \
 	echo "Switched to npm @pipelex/mthds-ui@$$VERSION. Review the diff, then commit package.json + yarn.lock."
 
-pin-mthds-ui: ## Pin mthds-ui to a GitHub tag (default: latest). Usage: make pin-mthds-ui [TAG=v0.3.0]
-	@if [ -n "$${TAG:-}" ]; then \
-		SHA=$$(gh api repos/Pipelex/mthds-ui/tags --jq ".[] | select(.name == \"$$TAG\") | .commit.sha") && \
-		if [ -z "$$SHA" ]; then echo "ERROR: Tag $$TAG not found in Pipelex/mthds-ui"; exit 1; fi; \
-	else \
-		PAIR=$$(gh api repos/Pipelex/mthds-ui/tags --jq '.[0] | "\(.name) \(.commit.sha)"') && \
-		TAG=$$(echo "$$PAIR" | cut -d' ' -f1) && SHA=$$(echo "$$PAIR" | cut -d' ' -f2) && \
-		if [ -z "$$TAG" ]; then echo "ERROR: No tags found in Pipelex/mthds-ui"; exit 1; fi; \
-	fi && \
-	echo "Pinning @pipelex/mthds-ui to $$TAG ($$SHA)" && \
-	cd $(EXT_DIR) && yarn add "@pipelex/mthds-ui@github:Pipelex/mthds-ui#$$SHA" && \
-	echo "Done. Review the diff, then commit package.json + yarn.lock."
-
 ul: use-local
 un: use-npm
-pmu: pin-mthds-ui
 
 $(GRAMMAR_DST): $(GRAMMAR_SRC)
 	@mkdir -p $(WEBSITE_SHIKI_DIR)

--- a/crates/taplo-lsp/src/lib.rs
+++ b/crates/taplo-lsp/src/lib.rs
@@ -16,7 +16,9 @@
     clippy::manual_let_else,
     clippy::map_unwrap_or,
     clippy::redundant_closure_for_method_calls,
-    clippy::uninlined_format_args
+    clippy::uninlined_format_args,
+    // New in clippy 1.95.0 — keep upstream folding_ranges.rs match arms as-is.
+    clippy::collapsible_match
 )]
 
 use lsp_async_stub::Server;

--- a/crates/taplo/src/lib.rs
+++ b/crates/taplo/src/lib.rs
@@ -1,4 +1,8 @@
 #![allow(clippy::single_match)]
+// Suppressed for upstream taplo code: keeps the source byte-for-byte identical
+// with tamasfe/taplo so future syncs stay clean. New lints from clippy 1.95.0.
+#![allow(clippy::unnecessary_sort_by)]
+#![allow(clippy::collapsible_match)]
 //! # About
 //!
 //! The main purpose of the library is to provide tools for analyzing TOML data where the

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -747,7 +747,7 @@
   },
   "dependencies": {
     "@pipelex/lsp": "portal:../../js/lsp",
-    "@pipelex/mthds-ui": "github:Pipelex/mthds-ui#838c0a3e57c3e19cf9d9b5fea806ca915cb820d3",
+    "@pipelex/mthds-ui": "npm:0.5.0",
     "deep-equal": "^2.2.3",
     "encoding": "^0.1.13",
     "fast-glob": "^3.3.2",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "pipelex",
   "displayName": "Pipelex",
   "description": "Pipelex extension for the MTHDS language",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "repository": {
     "url": "https://github.com/Pipelex/vscode-pipelex"
   },
@@ -747,7 +747,7 @@
   },
   "dependencies": {
     "@pipelex/lsp": "portal:../../js/lsp",
-    "@pipelex/mthds-ui": "npm:0.5.0",
+    "@pipelex/mthds-ui": "npm:0.5.1",
     "deep-equal": "^2.2.3",
     "encoding": "^0.1.13",
     "fast-glob": "^3.3.2",

--- a/editors/vscode/scripts/build.mjs
+++ b/editors/vscode/scripts/build.mjs
@@ -47,6 +47,10 @@ cpSync(
   "./node_modules/@pipelex/mthds-ui/dist/graph/react/detail/DetailPanel.css",
   "./dist/pipelex/graph/webview/detail-panel.css",
 );
+cpSync(
+  "./node_modules/@pipelex/mthds-ui/dist/graph/react/viewer/GraphToolbar.css",
+  "./dist/pipelex/graph/webview/graph-toolbar.css",
+);
 
 // Bundle webview TypeScript → single IIFE script
 // React, ReactDOM, @xyflow/react v12, dagre, and mthds-ui are all bundled.

--- a/editors/vscode/src/pipelex/__tests__/methodGraphPanel.test.ts
+++ b/editors/vscode/src/pipelex/__tests__/methodGraphPanel.test.ts
@@ -43,6 +43,16 @@ vi.mock('vscode', () => ({
             fsPath: parts.map((p: any) => p.fsPath || p).join('/'),
             toString: () => parts.map((p: any) => p.fsPath || p).join('/'),
         })),
+        parse: vi.fn((value: string, _strict?: boolean) => {
+            const match = /^([a-zA-Z][a-zA-Z0-9+\-.]*):/.exec(value);
+            if (!match) {
+                throw new Error(`invalid URI: ${value}`);
+            }
+            return { scheme: match[1].toLowerCase(), toString: () => value } as any;
+        }),
+    },
+    env: {
+        openExternal: vi.fn(() => Promise.resolve(true)),
     },
     Selection: vi.fn(),
     TextEditorRevealType: { InCenter: 2 },
@@ -467,5 +477,113 @@ describe('MethodGraphPanel', () => {
 
         const uri = makeUri('/project/file.mthds');
         expect(() => mockState.onDocChangeHandler!({ document: { uri, isDirty: false } })).not.toThrow();
+    });
+
+    // --- openExternally message handling ---
+
+    it('openExternally opens https URLs via vscode.env.openExternal', async () => {
+        const vscode = await import('vscode');
+        const output = mockOutput();
+        const panel = new MethodGraphPanel(output, makeExtensionUri());
+        const uri = makeUri('/project/file.mthds');
+        panel.show(uri);
+        await new Promise(r => setTimeout(r, 50));
+
+        const messageHandler = mockState.mockWebview.onDidReceiveMessage.mock.calls[0][0];
+        messageHandler({ type: 'openExternally', url: 'https://example.com/foo.pdf' });
+        await new Promise(r => setTimeout(r, 10));
+
+        expect(vscode.env.openExternal).toHaveBeenCalledTimes(1);
+        const calledWith = vi.mocked(vscode.env.openExternal).mock.calls[0][0] as any;
+        expect(calledWith.scheme).toBe('https');
+        panel.dispose();
+    });
+
+    it('openExternally opens http URLs', async () => {
+        const vscode = await import('vscode');
+        const panel = new MethodGraphPanel(mockOutput(), makeExtensionUri());
+        const uri = makeUri('/project/file.mthds');
+        panel.show(uri);
+        await new Promise(r => setTimeout(r, 50));
+
+        const messageHandler = mockState.mockWebview.onDidReceiveMessage.mock.calls[0][0];
+        messageHandler({ type: 'openExternally', url: 'http://example.com/foo.pdf' });
+        await new Promise(r => setTimeout(r, 10));
+
+        expect(vscode.env.openExternal).toHaveBeenCalledTimes(1);
+        panel.dispose();
+    });
+
+    it('openExternally refuses non-http(s) schemes (file:)', async () => {
+        const vscode = await import('vscode');
+        const output = mockOutput();
+        const panel = new MethodGraphPanel(output, makeExtensionUri());
+        const uri = makeUri('/project/file.mthds');
+        panel.show(uri);
+        await new Promise(r => setTimeout(r, 50));
+
+        const messageHandler = mockState.mockWebview.onDidReceiveMessage.mock.calls[0][0];
+        messageHandler({ type: 'openExternally', url: 'file:///etc/passwd' });
+        await new Promise(r => setTimeout(r, 10));
+
+        expect(vscode.env.openExternal).not.toHaveBeenCalled();
+        expect(output.appendLine).toHaveBeenCalledWith(
+            expect.stringContaining('refused')
+        );
+        panel.dispose();
+    });
+
+    it('openExternally refuses vscode: scheme', async () => {
+        const vscode = await import('vscode');
+        const panel = new MethodGraphPanel(mockOutput(), makeExtensionUri());
+        const uri = makeUri('/project/file.mthds');
+        panel.show(uri);
+        await new Promise(r => setTimeout(r, 50));
+
+        const messageHandler = mockState.mockWebview.onDidReceiveMessage.mock.calls[0][0];
+        messageHandler({ type: 'openExternally', url: 'vscode://settings' });
+        await new Promise(r => setTimeout(r, 10));
+
+        expect(vscode.env.openExternal).not.toHaveBeenCalled();
+        panel.dispose();
+    });
+
+    it('openExternally logs when openExternal returns false', async () => {
+        const vscode = await import('vscode');
+        vi.mocked(vscode.env.openExternal).mockResolvedValueOnce(false as any);
+
+        const output = mockOutput();
+        const panel = new MethodGraphPanel(output, makeExtensionUri());
+        const uri = makeUri('/project/file.mthds');
+        panel.show(uri);
+        await new Promise(r => setTimeout(r, 50));
+
+        const messageHandler = mockState.mockWebview.onDidReceiveMessage.mock.calls[0][0];
+        messageHandler({ type: 'openExternally', url: 'https://example.com/x.pdf' });
+        await new Promise(r => setTimeout(r, 10));
+
+        expect(output.appendLine).toHaveBeenCalledWith(
+            expect.stringContaining('OS declined')
+        );
+        panel.dispose();
+    });
+
+    it('openExternally logs and skips when URL is unparseable', async () => {
+        const vscode = await import('vscode');
+        const output = mockOutput();
+        const panel = new MethodGraphPanel(output, makeExtensionUri());
+        const uri = makeUri('/project/file.mthds');
+        panel.show(uri);
+        await new Promise(r => setTimeout(r, 50));
+
+        const messageHandler = mockState.mockWebview.onDidReceiveMessage.mock.calls[0][0];
+        messageHandler({ type: 'openExternally', url: 'not a url' });
+        await new Promise(r => setTimeout(r, 10));
+
+        expect(vscode.env.openExternal).not.toHaveBeenCalled();
+        expect(output.appendLine).toHaveBeenCalledWith(
+            expect.stringContaining('invalid URL')
+        );
+        panel.dispose();
     });
 });

--- a/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
+++ b/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
@@ -474,6 +474,18 @@ export class MethodGraphPanel implements vscode.Disposable {
         if (message.type === 'navigateToPipe' && message.pipeCode && this.currentUri) {
             if (this.sourceKind === 'graphspec-json') return;
             this.navigateToPipe(message.pipeCode);
+            return;
+        }
+        if (message.type === 'openExternally' && typeof message.url === 'string') {
+            // Webviews can't `window.open` or render <embed type="application/pdf">,
+            // so the StuffViewer routes both through here. Hand off to the OS via
+            // VS Code so the user gets their default browser/PDF viewer.
+            try {
+                const uri = vscode.Uri.parse(message.url, true);
+                vscode.env.openExternal(uri);
+            } catch (err: any) {
+                this.output.appendLine(`openExternally: invalid URL "${message.url}" — ${err.message ?? err}`);
+            }
         }
     }
 

--- a/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
+++ b/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
@@ -447,11 +447,13 @@ export class MethodGraphPanel implements vscode.Disposable {
         const jsUri = this.panel.webview.asWebviewUri(vscode.Uri.joinPath(webviewDir, 'graph.js'));
         const xyflowCssUri = this.panel.webview.asWebviewUri(vscode.Uri.joinPath(webviewDir, 'xyflow.css'));
         const graphCoreCssUri = this.panel.webview.asWebviewUri(vscode.Uri.joinPath(webviewDir, 'graph-core.css'));
+        const graphToolbarCssUri = this.panel.webview.asWebviewUri(vscode.Uri.joinPath(webviewDir, 'graph-toolbar.css'));
         const stuffViewerCssUri = this.panel.webview.asWebviewUri(vscode.Uri.joinPath(webviewDir, 'stuff-viewer.css'));
         const detailPanelCssUri = this.panel.webview.asWebviewUri(vscode.Uri.joinPath(webviewDir, 'detail-panel.css'));
 
         html = html.replace('{{XYFLOW_CSS_URI}}', xyflowCssUri.toString());
         html = html.replace('{{GRAPH_CORE_CSS_URI}}', graphCoreCssUri.toString());
+        html = html.replace('{{GRAPH_TOOLBAR_CSS_URI}}', graphToolbarCssUri.toString());
         html = html.replace('{{GRAPH_CSS_URI}}', cssUri.toString());
         html = html.replace('{{STUFF_VIEWER_CSS_URI}}', stuffViewerCssUri.toString());
         html = html.replace('{{DETAIL_PANEL_CSS_URI}}', detailPanelCssUri.toString());
@@ -467,24 +469,6 @@ export class MethodGraphPanel implements vscode.Disposable {
                 this.panel.webview.postMessage(this.pendingData);
                 this.pendingData = null;
             }
-            return;
-        }
-        if (message.type === 'updateDirection' && typeof message.value === 'string') {
-            const cfg = vscode.workspace.getConfiguration('pipelex');
-            const target = vscode.workspace.workspaceFolders?.length
-                ? vscode.ConfigurationTarget.Workspace
-                : vscode.ConfigurationTarget.Global;
-            // Map Dagre format (LR/TB) back → VS Code setting (left_to_right/top_down)
-            const settingValue = message.value === 'LR' ? 'left_to_right' : 'top_down';
-            cfg.update('graph.direction', settingValue, target);
-            return;
-        }
-        if (message.type === 'updateShowControllers' && typeof message.value === 'boolean') {
-            const cfg = vscode.workspace.getConfiguration('pipelex');
-            const target = vscode.workspace.workspaceFolders?.length
-                ? vscode.ConfigurationTarget.Workspace
-                : vscode.ConfigurationTarget.Global;
-            cfg.update('graph.showControllers', message.value, target);
             return;
         }
         if (message.type === 'navigateToPipe' && message.pipeCode && this.currentUri) {

--- a/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
+++ b/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
@@ -480,12 +480,27 @@ export class MethodGraphPanel implements vscode.Disposable {
             // Webviews can't `window.open` or render <embed type="application/pdf">,
             // so the StuffViewer routes both through here. Hand off to the OS via
             // VS Code so the user gets their default browser/PDF viewer.
-            try {
-                const uri = vscode.Uri.parse(message.url, true);
-                vscode.env.openExternal(uri);
-            } catch (err: any) {
-                this.output.appendLine(`openExternally: invalid URL "${message.url}" — ${err.message ?? err}`);
-            }
+            this.openExternally(message.url);
+        }
+    }
+
+    private async openExternally(url: string) {
+        let uri: vscode.Uri;
+        try {
+            uri = vscode.Uri.parse(url, true);
+        } catch (err: any) {
+            this.output.appendLine(`openExternally: invalid URL "${url}" — ${err.message ?? err}`);
+            return;
+        }
+        // Only http(s) — refuse file:, vscode:, and other registered-handler schemes
+        // that could be triggered by a malicious or accidental GraphSpec payload.
+        if (uri.scheme !== 'http' && uri.scheme !== 'https') {
+            this.output.appendLine(`openExternally: refused non-http(s) URL "${url}" (scheme: ${uri.scheme})`);
+            return;
+        }
+        const opened = await vscode.env.openExternal(uri);
+        if (!opened) {
+            this.output.appendLine(`openExternally: OS declined to open "${url}"`);
         }
     }
 

--- a/editors/vscode/src/pipelex/graph/webview/adapter.ts
+++ b/editors/vscode/src/pipelex/graph/webview/adapter.ts
@@ -38,6 +38,14 @@ function onReactFlowInit(instance: any) {
     reactFlowInstance = instance;
 }
 
+// VS Code webviews run in Electron, which ships without Chromium's PDFium
+// plugin (electron/electron#12337). `<embed type="application/pdf">` and
+// `window.open` therefore don't work — route through the extension host
+// (vscode.env.openExternal) via postMessage instead.
+function onOpenExternally(url: string, filename?: string) {
+    vscode.postMessage({ type: 'openExternally', url, filename });
+}
+
 // --- Message handling ---
 
 function handleMessage(event: { data: any }) {
@@ -101,6 +109,8 @@ function App() {
         config: currentConfig,
         onNavigateToPipe,
         onReactFlowInit,
+        canEmbedPdf: false,
+        onOpenExternally,
     });
 }
 

--- a/editors/vscode/src/pipelex/graph/webview/adapter.ts
+++ b/editors/vscode/src/pipelex/graph/webview/adapter.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import type { GraphSpec, GraphConfig, GraphDirection } from '@pipelex/mthds-ui';
+import type { GraphSpec, GraphConfig } from '@pipelex/mthds-ui';
 import { GraphViewer } from '@pipelex/mthds-ui/graph/react';
 
 // VS Code webview API
@@ -16,50 +16,17 @@ const _globalListener = function(event: MessageEvent) {
 };
 window.addEventListener('message', _globalListener);
 
-// State managed by the adapter, passed as props to GraphViewer
-let currentDirection: GraphDirection = 'TB';
+// State managed by the adapter, passed as props to GraphViewer.
+// Direction and showControllers seeds live in `currentConfig` — GraphViewer
+// reads `config.direction` / `config.showControllers` as initial values and
+// owns those toggles internally afterward (mthds-ui v0.4+).
 let currentGraphspec: GraphSpec | null = null;
 let currentConfig: GraphConfig = {};
-let currentShowControllers = false;
 let currentUri: string | null = null;
 let renderApp: (() => void) | null = null;
 
-// Expose ReactFlow instance for zoom toolbar buttons
+// Held so we can preserve the viewport across same-file refreshes.
 let reactFlowInstance: any = null;
-
-// Direction icon update
-function applyDirectionIcon(direction: string) {
-    document.querySelectorAll('.direction-icon').forEach(icon => icon.classList.remove('active'));
-    const targetIcon = document.querySelector(direction === 'LR' ? '.tb-icon' : '.lr-icon');
-    if (targetIcon) targetIcon.classList.add('active');
-}
-
-// Direction toggle button
-document.getElementById('direction-toggle')!.addEventListener('click', () => {
-    currentDirection = currentDirection === 'LR' ? 'TB' : 'LR';
-    applyDirectionIcon(currentDirection);
-    vscode.postMessage({ type: 'updateDirection', value: currentDirection });
-    if (renderApp) renderApp();
-});
-
-// Zoom toolbar buttons
-document.getElementById('zoom-in')!.addEventListener('click', () => {
-    if (reactFlowInstance) reactFlowInstance.zoomIn();
-});
-document.getElementById('zoom-out')!.addEventListener('click', () => {
-    if (reactFlowInstance) reactFlowInstance.zoomOut();
-});
-document.getElementById('zoom-fit')!.addEventListener('click', () => {
-    if (reactFlowInstance) reactFlowInstance.fitView({ padding: 0.1 });
-});
-
-// Controllers toggle switch
-const controllersToggle = document.getElementById('controllers-toggle') as HTMLInputElement;
-controllersToggle.addEventListener('change', () => {
-    currentShowControllers = controllersToggle.checked;
-    vscode.postMessage({ type: 'updateShowControllers', value: currentShowControllers });
-    if (renderApp) renderApp();
-});
 
 // --- Callbacks passed to GraphViewer ---
 
@@ -69,7 +36,6 @@ function onNavigateToPipe(pipeCode: string) {
 
 function onReactFlowInit(instance: any) {
     reactFlowInstance = instance;
-    (window as any)._reactFlowInstance = instance;
 }
 
 // --- Message handling ---
@@ -101,10 +67,6 @@ function handleMessage(event: { data: any }) {
 
         currentGraphspec = message.graphspec || null;
         currentConfig = message.config || {};
-        currentDirection = (currentConfig.direction || 'TB') as GraphDirection;
-        currentShowControllers = currentConfig.showControllers || false;
-        controllersToggle.checked = currentShowControllers;
-        applyDirectionIcon(currentDirection);
 
         // Apply palette colors as CSS custom properties on <body>
         if (currentConfig.paletteColors) {
@@ -137,8 +99,6 @@ function App() {
     return React.createElement(GraphViewer, {
         graphspec: currentGraphspec,
         config: currentConfig,
-        direction: currentDirection,
-        showControllers: currentShowControllers,
         onNavigateToPipe,
         onReactFlowInit,
     });
@@ -161,6 +121,3 @@ for (const queued of _preReactQueue) {
     handleMessage({ data: queued });
 }
 _preReactQueue.length = 0;
-
-// Apply initial direction icon
-applyDirectionIcon(currentDirection);

--- a/editors/vscode/src/pipelex/graph/webview/graph.css
+++ b/editors/vscode/src/pipelex/graph/webview/graph.css
@@ -158,8 +158,7 @@ body {
 #app-container {
     display: flex;
     flex-direction: row;
-    margin-top: 37px;
-    height: calc(100vh - 37px); /* Leave room for toolbar */
+    height: 100vh;
 }
 #root {
     position: relative;
@@ -198,88 +197,4 @@ body {
     flex: 1;
     min-height: 0;
     overflow: auto;
-}
-/* Toolbar */
-.toolbar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    background: var(--color-surface);
-    border-bottom: 1px solid var(--color-border);
-    padding: 4px 16px;
-    display: flex;
-    align-items: center;
-    z-index: 100;
-    height: 37px;
-}
-.toolbar-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-    background: var(--color-surface-hover);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.15s ease;
-    color: var(--color-text-muted);
-}
-.toolbar-btn:hover {
-    background: var(--color-accent);
-    border-color: var(--color-accent);
-    color: white;
-}
-.toolbar-spacer {
-    flex: 1;
-}
-.toolbar-zoom {
-    display: flex;
-    gap: 4px;
-}
-.direction-icon { display: none; }
-.direction-icon.active { display: inline-flex; align-items: center; justify-content: center; }
-/* Toggle switch */
-.toggle-switch {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    cursor: pointer;
-    margin-left: 8px;
-    user-select: none;
-}
-.toggle-switch input {
-    display: none;
-}
-.toggle-track {
-    position: relative;
-    width: 32px;
-    height: 18px;
-    background: var(--color-border);
-    border-radius: 9px;
-    transition: background 0.2s ease;
-}
-.toggle-knob {
-    position: absolute;
-    top: 2px;
-    left: 2px;
-    width: 14px;
-    height: 14px;
-    background: var(--color-text-muted);
-    border-radius: 50%;
-    transition: transform 0.2s ease, background 0.2s ease;
-}
-.toggle-switch input:checked + .toggle-track {
-    background: var(--color-accent);
-}
-.toggle-switch input:checked + .toggle-track .toggle-knob {
-    transform: translateX(14px);
-    background: white;
-}
-.toggle-label {
-    font-size: 12px;
-    font-family: var(--font-sans);
-    color: var(--color-text-muted);
-    line-height: 1;
 }

--- a/editors/vscode/src/pipelex/graph/webview/graph.html
+++ b/editors/vscode/src/pipelex/graph/webview/graph.html
@@ -6,28 +6,12 @@
 <title>Method Graph</title>
 <link rel="stylesheet" href="{{XYFLOW_CSS_URI}}">
 <link rel="stylesheet" href="{{GRAPH_CORE_CSS_URI}}">
+<link rel="stylesheet" href="{{GRAPH_TOOLBAR_CSS_URI}}">
 <link rel="stylesheet" href="{{GRAPH_CSS_URI}}">
 <link rel="stylesheet" href="{{STUFF_VIEWER_CSS_URI}}">
 <link rel="stylesheet" href="{{DETAIL_PANEL_CSS_URI}}">
 </head>
 <body>
-<div class="toolbar">
-    <button id="direction-toggle" class="toolbar-btn" title="Toggle layout direction">
-        <span class="direction-icon lr-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg></span>
-        <span class="direction-icon tb-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><polyline points="19 12 12 19 5 12"/></svg></span>
-    </button>
-    <label class="toggle-switch" title="Show/hide controller containers">
-        <input type="checkbox" id="controllers-toggle">
-        <span class="toggle-track"><span class="toggle-knob"></span></span>
-        <span class="toggle-label">Controllers</span>
-    </label>
-    <div class="toolbar-spacer"></div>
-    <div class="toolbar-zoom">
-        <button id="zoom-out" class="toolbar-btn" title="Zoom out"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/></svg></button>
-        <button id="zoom-in" class="toolbar-btn" title="Zoom in"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></button>
-        <button id="zoom-fit" class="toolbar-btn" title="Fit to view"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7"/></svg></button>
-    </div>
-</div>
 <div id="app-container">
     <div id="root"></div>
 </div>

--- a/editors/vscode/yarn.lock
+++ b/editors/vscode/yarn.lock
@@ -483,9 +483,9 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@pipelex/mthds-ui@npm:0.5.0":
-  version: 0.5.0
-  resolution: "@pipelex/mthds-ui@npm:0.5.0"
+"@pipelex/mthds-ui@npm:0.5.1":
+  version: 0.5.1
+  resolution: "@pipelex/mthds-ui@npm:0.5.1"
   dependencies:
     "@xyflow/react": "npm:^12"
     dompurify: "npm:^3.3.3"
@@ -501,7 +501,7 @@ __metadata:
       optional: true
     shiki:
       optional: true
-  checksum: 60bc266d033bf4e416161d797844cc2f4ea29391451302aab24970eefd2c23601b1c72f488d430b8e1695989efa930dadb209a0f880140e1bffa741d3c15c0d0
+  checksum: 2cffa88b9dbada890b959d611b9c71798820f52af9e4895363d173ec10b14d694dae891567d02e189c090508e4887bece41c88efff2e5d5eafe15444b57d367b
   languageName: node
   linkType: hard
 
@@ -3471,7 +3471,7 @@ __metadata:
   resolution: "pipelex@workspace:."
   dependencies:
     "@pipelex/lsp": "portal:../../js/lsp"
-    "@pipelex/mthds-ui": "npm:0.5.0"
+    "@pipelex/mthds-ui": "npm:0.5.1"
     "@rollup/plugin-commonjs": "npm:^25.0.7"
     "@rollup/plugin-node-resolve": "npm:^15.2.3"
     "@rollup/plugin-replace": "npm:^5.0.5"

--- a/editors/vscode/yarn.lock
+++ b/editors/vscode/yarn.lock
@@ -483,9 +483,9 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@pipelex/mthds-ui@github:Pipelex/mthds-ui#838c0a3e57c3e19cf9d9b5fea806ca915cb820d3":
-  version: 0.3.4
-  resolution: "@pipelex/mthds-ui@https://github.com/Pipelex/mthds-ui.git#commit=838c0a3e57c3e19cf9d9b5fea806ca915cb820d3"
+"@pipelex/mthds-ui@npm:0.5.0":
+  version: 0.5.0
+  resolution: "@pipelex/mthds-ui@npm:0.5.0"
   dependencies:
     "@xyflow/react": "npm:^12"
     dompurify: "npm:^3.3.3"
@@ -501,7 +501,7 @@ __metadata:
       optional: true
     shiki:
       optional: true
-  checksum: f6646c5846aa0c5e0daebfce7c3624b047a7a98ba359862f42968a42dfd2e5be4e66ffeac7a31d02a9bfb2af43c515f82975a3416aeb570f00e49da0bcdae8ac
+  checksum: 60bc266d033bf4e416161d797844cc2f4ea29391451302aab24970eefd2c23601b1c72f488d430b8e1695989efa930dadb209a0f880140e1bffa741d3c15c0d0
   languageName: node
   linkType: hard
 
@@ -3471,7 +3471,7 @@ __metadata:
   resolution: "pipelex@workspace:."
   dependencies:
     "@pipelex/lsp": "portal:../../js/lsp"
-    "@pipelex/mthds-ui": "github:Pipelex/mthds-ui#838c0a3e57c3e19cf9d9b5fea806ca915cb820d3"
+    "@pipelex/mthds-ui": "npm:0.5.0"
     "@rollup/plugin-commonjs": "npm:^25.0.7"
     "@rollup/plugin-node-resolve": "npm:^15.2.3"
     "@rollup/plugin-replace": "npm:^5.0.5"


### PR DESCRIPTION
## Summary
- Fix blank PDF previews in the Method Graph viewer by falling back to a clickable "Open externally" tile (Electron webviews lack PDFium, so `<embed type="application/pdf">` was never going to render). Click hands the URL to `vscode.env.openExternal`.
- Bump `@pipelex/mthds-ui` to `0.5.1` — adds `canEmbedPdf` and `onOpenExternally` props on `StuffViewer`/`ConceptDetailPanel`/`GraphViewer`, threaded through and wired up by the extension's webview adapter and graph panel.
- Extension `0.6.4 → 0.6.5`. CLI/common/LSP crates untouched.

## Test plan
- [ ] Open a live-run GraphSpec JSON (e.g. `pipelex-codex-demo/mthds-wip/cv_screening/live_run_graph.json`) with PDF stuff items
- [ ] Click a PDF stuff node → detail panel shows a clickable file tile (filename + "Click to open PDF externally")
- [ ] Click the tile → PDF opens in OS default PDF viewer / browser
- [ ] Toolbar "open in new window" icon also opens externally (no silent failure)
- [ ] Image stuff nodes still preview inline (regression check)
- [ ] Non-PDF, non-image stuff nodes still render JSON/text/HTML tabs
- [ ] Open a `.mthds` file → method graph still renders unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix blank PDF previews in the Method Graph viewer by showing an “Open externally” tile and routing clicks through `vscode.env.openExternal` with http/https-only checks. Releases the VS Code extension as v0.6.5 and switches to `@pipelex/mthds-ui` 0.5.1 from npm with the built-in GraphToolbar.

- **Bug Fixes**
  - PDFs now show a clickable “Open externally” tile instead of a blank embed.
  - Clicks go through `vscode.env.openExternal`; only http/https URLs are allowed and failures are logged.
  - Webview adapter wires `canEmbedPdf=false` and `onOpenExternally`.
  - Add tests for allowed/refused schemes, unparseable URLs, and OS declinations.
  - CI: allow new Clippy 1.95 lints in upstream taplo crates (no behavior change).

- **Dependencies**
  - Update `@pipelex/mthds-ui` to `0.5.1` from npm; adopt `GraphToolbar` and copy `GraphToolbar.css` in the build.
  - Makefile/hooks: add `use-npm`, drop `use-github`, remove `pin-mthds-ui`, and enforce the npm spec in pre-commit/CI.

<sup>Written for commit 27b189f239b4ce76385abbbb2396ab3b19db9d1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

