### PR TITLE
Release v0.7.0 + plxt 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Pipelex IDE Extension and `plxt` CLI Changelog
 
+## [0.7.0] - 2026-05-12
+
+### Added
+- New setting `pipelex.graph.foldMode` (`folded` / `expanded` / `auto`, default `folded`) controls the initial fold state of pipe controllers when a method graph opens. Users can still fold/unfold individual controllers via the in-graph toolbar afterwards. `auto` is reserved for future renderer-defined heuristics and currently behaves like `expanded`
+
+### Changed
+- `pipelex.graph.showControllers` default flipped from `false` to `true` — controller group boxes are now shown by default in the method graph. Users who previously relied on the default-off behavior will need to set this to `false` in their settings
+- Upgrade @pipelex/mthds-ui to v0.6.0 — adds `initialFoldMode` prop on `GraphViewer` and `foldMode` field on `GraphConfig` so the extension can seed the controller fold state on first render
+
+### Fixed
+- Method graph webview no longer ignores `pipelex.graph.direction` and `pipelex.graph.showControllers` on first mount. The webview adapter previously rendered `GraphViewer` with an empty config before the host's `setData` message arrived; `direction`/`showControllers` are `useState` values seeded only on first render, so they latched to mthds-ui defaults and never picked up the host's preferences. The adapter now defers the mount until config arrives
+
 ## [0.6.5] - 2026-05-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Pipelex IDE Extension and `plxt` CLI Changelog
 
+## [0.4.0] - 2026-05-12
+
+### Changed
+- Update bundled MTHDS schema to v0.27.0 — adds `PipeStructure` blueprint, new `render_js`/`include_raw_html` PDF options, and `xhigh` reasoning effort level (plxt 0.4.0)
+
 ## [0.7.0] - 2026-05-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Pipelex IDE Extension and `plxt` CLI Changelog
 
-## [0.4.0] - 2026-05-12
-
-### Changed
-- Update bundled MTHDS schema to v0.27.0 — adds `PipeStructure` blueprint, new `render_js`/`include_raw_html` PDF options, and `xhigh` reasoning effort level (plxt 0.4.0)
-
 ## [0.7.0] - 2026-05-12
 
 ### Added
@@ -12,10 +7,11 @@
 
 ### Changed
 - `pipelex.graph.showControllers` default flipped from `false` to `true` — controller group boxes are now shown by default in the method graph. Users who previously relied on the default-off behavior will need to set this to `false` in their settings
-- Upgrade @pipelex/mthds-ui to v0.6.0 — adds `initialFoldMode` prop on `GraphViewer` and `foldMode` field on `GraphConfig` so the extension can seed the controller fold state on first render
+- Upgrade @pipelex/mthds-ui to v0.6.1 — adds `initialFoldMode` prop on `GraphViewer` and `foldMode` field on `GraphConfig` so the extension can seed the controller fold state on first render
+- Update bundled MTHDS schema to v0.27.0 — adds `PipeStructure` blueprint, new `render_js`/`include_raw_html` PDF options, and `xhigh` reasoning effort level (plxt 0.4.0)
 
 ### Fixed
-- Method graph webview no longer ignores `pipelex.graph.direction` and `pipelex.graph.showControllers` on first mount. The webview adapter previously rendered `GraphViewer` with an empty config before the host's `setData` message arrived; `direction`/`showControllers` are `useState` values seeded only on first render, so they latched to mthds-ui defaults and never picked up the host's preferences. The adapter now defers the mount until config arrives
+- Method graph webview no longer ignores `pipelex.graph.direction`, `pipelex.graph.showControllers`, and `pipelex.graph.foldMode` when opening a method graph. The webview adapter previously mounted `GraphViewer` once with an empty config before the host's `setData` arrived and then reconciled the same instance across file switches; those settings are `useState` values seeded only on first render, so they latched to mthds-ui defaults (or to the first graph's config) and never picked up the host's preferences on subsequent opens. The adapter now defers the mount until config arrives and remounts the viewer when the panel is reused for a different file URI
 
 ## [0.6.5] - 2026-05-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,7 +1574,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipelex-cli"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-ctrlc",

--- a/crates/pipelex-cli/Cargo.toml
+++ b/crates/pipelex-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "pipelex-cli"
 description  = "Pipelex Tools CLI (plxt) - wraps taplo-cli with MTHDS support"
-version      = "0.3.3"
+version      = "0.4.0"
 rust-version = { workspace = true }
 authors      = { workspace = true }
 edition      = { workspace = true }

--- a/crates/taplo-common/schemas/mthds_schema.json
+++ b/crates/taplo-common/schemas/mthds_schema.json
@@ -86,6 +86,9 @@
                 "$ref": "#/definitions/PipeSearchBlueprint"
               },
               {
+                "$ref": "#/definitions/PipeStructureBlueprint"
+              },
+              {
                 "$ref": "#/definitions/PipeBatchBlueprint"
               },
               {
@@ -1053,6 +1056,30 @@
           ],
           "default": null,
           "title": "Page Views Dpi"
+        },
+        "render_js": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Render Js"
+        },
+        "include_raw_html": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Include Raw Html"
         }
       },
       "required": [
@@ -1623,6 +1650,66 @@
       "title": "PipeSequenceBlueprint",
       "type": "object"
     },
+    "PipeStructureBlueprint": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "default": "PipeStructure",
+          "title": "Type",
+          "type": "string",
+          "enum": [
+            "PipeStructure"
+          ]
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "inputs": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inputs"
+        },
+        "output": {
+          "title": "Output",
+          "type": "string"
+        },
+        "model": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LLMSetting"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ModelReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Model"
+        }
+      },
+      "required": [
+        "description",
+        "output"
+      ],
+      "title": "PipeStructureBlueprint",
+      "type": "object"
+    },
     "PromptImageDetail": {
       "enum": [
         "high",
@@ -1659,6 +1746,7 @@
         "low",
         "medium",
         "high",
+        "xhigh",
         "max"
       ],
       "title": "ReasoningEffort",
@@ -1899,7 +1987,7 @@
     }
   },
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "$comment": "Generated from PipelexBundleBlueprint v0.20.0. Do not edit manually.",
+  "$comment": "Generated from PipelexBundleBlueprint v0.27.0. Do not edit manually.",
   "x-taplo": {
     "initKeys": [
       "domain"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -763,7 +763,7 @@
   },
   "dependencies": {
     "@pipelex/lsp": "portal:../../js/lsp",
-    "@pipelex/mthds-ui": "npm:0.6.0",
+    "@pipelex/mthds-ui": "npm:0.6.1",
     "deep-equal": "^2.2.3",
     "encoding": "^0.1.13",
     "fast-glob": "^3.3.2",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -763,7 +763,7 @@
   },
   "dependencies": {
     "@pipelex/lsp": "portal:../../js/lsp",
-    "@pipelex/mthds-ui": "npm:0.6.1",
+    "@pipelex/mthds-ui": "npm:0.6.3",
     "deep-equal": "^2.2.3",
     "encoding": "^0.1.13",
     "fast-glob": "^3.3.2",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "pipelex",
   "displayName": "Pipelex",
   "description": "Pipelex extension for the MTHDS language",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "repository": {
     "url": "https://github.com/Pipelex/vscode-pipelex"
   },
@@ -607,7 +607,23 @@
           "description": "Show controller group boxes in the method graph.",
           "type": "boolean",
           "scope": "resource",
-          "default": false
+          "default": true
+        },
+        "pipelex.graph.foldMode": {
+          "description": "Initial fold state for pipe controllers when a method graph opens. Users can still toggle individual controllers via the in-graph toolbar.",
+          "type": "string",
+          "enum": [
+            "folded",
+            "expanded",
+            "auto"
+          ],
+          "enumDescriptions": [
+            "Fold all controllers into single pipe cards",
+            "Expand all controllers as group wrappers",
+            "Let the graph renderer decide (reserved for future heuristics)"
+          ],
+          "scope": "resource",
+          "default": "folded"
         },
         "pipelex.formatter.alignEntries": {
           "scope": "resource",
@@ -747,7 +763,7 @@
   },
   "dependencies": {
     "@pipelex/lsp": "portal:../../js/lsp",
-    "@pipelex/mthds-ui": "npm:0.5.1",
+    "@pipelex/mthds-ui": "npm:0.6.0",
     "deep-equal": "^2.2.3",
     "encoding": "^0.1.13",
     "fast-glob": "^3.3.2",

--- a/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
+++ b/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
@@ -257,7 +257,8 @@ export class MethodGraphPanel implements vscode.Disposable {
         const pipelexConfig = vscode.workspace.getConfiguration('pipelex');
         const timeout = pipelexConfig.get<number>('validation.timeout', 30000);
         const direction = pipelexConfig.get<string>('graph.direction', 'top_down');
-        const showControllers = pipelexConfig.get<boolean>('graph.showControllers', false);
+        const showControllers = pipelexConfig.get<boolean>('graph.showControllers', true);
+        const foldMode = pipelexConfig.get<string>('graph.foldMode', 'folded');
         const filePath = uri.fsPath;
         const args = [...resolved.args, 'validate', 'bundle', filePath, '--view', '--direction', direction];
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
@@ -289,7 +290,7 @@ export class MethodGraphPanel implements vscode.Disposable {
             if (controller.signal.aborted) return;
             if (this.currentUri?.toString() !== uri.toString()) return;
 
-            await this.sendGraphspecToWebview(uri, result.graphspec, direction, showControllers);
+            await this.sendGraphspecToWebview(uri, result.graphspec, direction, showControllers, foldMode);
         } catch (err: any) {
             if (controller.signal.aborted) return;
             if (this.currentUri?.toString() !== uri.toString()) return;
@@ -378,9 +379,10 @@ export class MethodGraphPanel implements vscode.Disposable {
 
         const pipelexConfig = vscode.workspace.getConfiguration('pipelex');
         const direction = pipelexConfig.get<string>('graph.direction', 'top_down');
-        const showControllers = pipelexConfig.get<boolean>('graph.showControllers', false);
+        const showControllers = pipelexConfig.get<boolean>('graph.showControllers', true);
+        const foldMode = pipelexConfig.get<string>('graph.foldMode', 'folded');
 
-        await this.sendGraphspecToWebview(uri, graphspec, direction, showControllers);
+        await this.sendGraphspecToWebview(uri, graphspec, direction, showControllers, foldMode);
     }
 
     private async sendGraphspecToWebview(
@@ -388,6 +390,7 @@ export class MethodGraphPanel implements vscode.Disposable {
         graphspec: unknown,
         direction: string,
         showControllers: boolean,
+        foldMode: string,
     ) {
         if (!this.panel) return;
 
@@ -413,6 +416,7 @@ export class MethodGraphPanel implements vscode.Disposable {
             config: {
                 direction: dagreDirection,
                 showControllers,
+                foldMode,
                 nodesep: graphConfig.nodesep,
                 ranksep: graphConfig.ranksep,
                 edgeType: graphConfig.edgeType,

--- a/editors/vscode/src/pipelex/graph/webview/adapter.ts
+++ b/editors/vscode/src/pipelex/graph/webview/adapter.ts
@@ -109,8 +109,16 @@ function App() {
     // useState initializers that only run on first render; if we mount with an
     // empty config (the pre-message state), those toggles latch to the
     // mthds-ui defaults and never pick up the host's preferences.
+    //
+    // Keying on `currentUri` forces a remount when the panel is reused for a
+    // different file (methodGraphPanel.show() reveals the existing panel
+    // instead of recreating it). Without the key, React reconciles a single
+    // GraphViewer instance across files and the useState-seeded toggles stay
+    // latched to the first graph's config. Same-URI refreshes (save) keep the
+    // same key, preserving viewport + interactive state as before.
     if (currentGraphspec === null) return null;
     return React.createElement(GraphViewer, {
+        key: currentUri ?? 'graphviewer',
         graphspec: currentGraphspec,
         config: currentConfig,
         onNavigateToPipe,

--- a/editors/vscode/src/pipelex/graph/webview/adapter.ts
+++ b/editors/vscode/src/pipelex/graph/webview/adapter.ts
@@ -104,6 +104,12 @@ function handleMessage(event: { data: any }) {
 // --- React mount ---
 
 function App() {
+    // Defer mounting GraphViewer until setData arrives. The viewer reads
+    // `config.direction`, `config.showControllers`, and `config.foldMode` in
+    // useState initializers that only run on first render; if we mount with an
+    // empty config (the pre-message state), those toggles latch to the
+    // mthds-ui defaults and never pick up the host's preferences.
+    if (currentGraphspec === null) return null;
     return React.createElement(GraphViewer, {
         graphspec: currentGraphspec,
         config: currentConfig,

--- a/editors/vscode/yarn.lock
+++ b/editors/vscode/yarn.lock
@@ -483,9 +483,9 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@pipelex/mthds-ui@npm:0.6.1":
-  version: 0.6.1
-  resolution: "@pipelex/mthds-ui@npm:0.6.1"
+"@pipelex/mthds-ui@npm:0.6.3":
+  version: 0.6.3
+  resolution: "@pipelex/mthds-ui@npm:0.6.3"
   dependencies:
     "@xyflow/react": "npm:^12"
     dompurify: "npm:^3.3.3"
@@ -501,7 +501,7 @@ __metadata:
       optional: true
     shiki:
       optional: true
-  checksum: 78f774bd73bd0ebb692c8cda8b7e77c564c1c4842d2d313359b77618a24207f456536269a46a9a5dd72b4bb7c601a396b9a2d93a84f68387d09f3bbe7db096c4
+  checksum: 8cb2772cf19a83501e34c13e362eae5ff5b005802fbfe93345d4dabe88e597cc5707bb940f8ad2e544d3f46aa6085cc52749f29b880962f7a4ded6b914256466
   languageName: node
   linkType: hard
 
@@ -3471,7 +3471,7 @@ __metadata:
   resolution: "pipelex@workspace:."
   dependencies:
     "@pipelex/lsp": "portal:../../js/lsp"
-    "@pipelex/mthds-ui": "npm:0.6.1"
+    "@pipelex/mthds-ui": "npm:0.6.3"
     "@rollup/plugin-commonjs": "npm:^25.0.7"
     "@rollup/plugin-node-resolve": "npm:^15.2.3"
     "@rollup/plugin-replace": "npm:^5.0.5"

--- a/editors/vscode/yarn.lock
+++ b/editors/vscode/yarn.lock
@@ -483,9 +483,9 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@pipelex/mthds-ui@npm:0.6.0":
-  version: 0.6.0
-  resolution: "@pipelex/mthds-ui@npm:0.6.0"
+"@pipelex/mthds-ui@npm:0.6.1":
+  version: 0.6.1
+  resolution: "@pipelex/mthds-ui@npm:0.6.1"
   dependencies:
     "@xyflow/react": "npm:^12"
     dompurify: "npm:^3.3.3"
@@ -501,7 +501,7 @@ __metadata:
       optional: true
     shiki:
       optional: true
-  checksum: 9a292338a9cba7611e63b38e12085e4b335bdf8c8887a24240fcd89c77dadde81d8000a88253d9532b648d8b350e7aee3faa722c92918a37c08caa7328e34c5a
+  checksum: 78f774bd73bd0ebb692c8cda8b7e77c564c1c4842d2d313359b77618a24207f456536269a46a9a5dd72b4bb7c601a396b9a2d93a84f68387d09f3bbe7db096c4
   languageName: node
   linkType: hard
 
@@ -3471,7 +3471,7 @@ __metadata:
   resolution: "pipelex@workspace:."
   dependencies:
     "@pipelex/lsp": "portal:../../js/lsp"
-    "@pipelex/mthds-ui": "npm:0.6.0"
+    "@pipelex/mthds-ui": "npm:0.6.1"
     "@rollup/plugin-commonjs": "npm:^25.0.7"
     "@rollup/plugin-node-resolve": "npm:^15.2.3"
     "@rollup/plugin-replace": "npm:^5.0.5"

--- a/editors/vscode/yarn.lock
+++ b/editors/vscode/yarn.lock
@@ -483,9 +483,9 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@pipelex/mthds-ui@npm:0.5.1":
-  version: 0.5.1
-  resolution: "@pipelex/mthds-ui@npm:0.5.1"
+"@pipelex/mthds-ui@npm:0.6.0":
+  version: 0.6.0
+  resolution: "@pipelex/mthds-ui@npm:0.6.0"
   dependencies:
     "@xyflow/react": "npm:^12"
     dompurify: "npm:^3.3.3"
@@ -501,7 +501,7 @@ __metadata:
       optional: true
     shiki:
       optional: true
-  checksum: 2cffa88b9dbada890b959d611b9c71798820f52af9e4895363d173ec10b14d694dae891567d02e189c090508e4887bece41c88efff2e5d5eafe15444b57d367b
+  checksum: 9a292338a9cba7611e63b38e12085e4b335bdf8c8887a24240fcd89c77dadde81d8000a88253d9532b648d8b350e7aee3faa722c92918a37c08caa7328e34c5a
   languageName: node
   linkType: hard
 
@@ -3471,7 +3471,7 @@ __metadata:
   resolution: "pipelex@workspace:."
   dependencies:
     "@pipelex/lsp": "portal:../../js/lsp"
-    "@pipelex/mthds-ui": "npm:0.5.1"
+    "@pipelex/mthds-ui": "npm:0.6.0"
     "@rollup/plugin-commonjs": "npm:^25.0.7"
     "@rollup/plugin-node-resolve": "npm:^15.2.3"
     "@rollup/plugin-replace": "npm:^5.0.5"


### PR DESCRIPTION
## Summary
- Extension v0.7.0: method-graph fold-mode preference, `showControllers` default flipped to true, mthds-ui bumped to 0.6.1
- plxt CLI 0.4.0: bundled MTHDS schema updated to v0.27.0 (PipeStructure blueprint, render_js/include_raw_html PDF options, xhigh reasoning effort)

## Test plan
- [ ] CI passes (fmt, clippy, tests, WASM check)
- [ ] Auto-tag job creates `pipelex-vscode-ext/v0.7.0` and `plxt-cli/v0.4.0`
- [ ] Marketplace + Open VSX + PyPI publishes succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.7.0 of the Pipelex VS Code extension and `plxt` 0.4.0. Adds controller fold mode, shows controllers by default, and updates the bundled MTHDS schema to v0.27.0.

- **New Features**
  - VS Code: add `pipelex.graph.foldMode` (`folded`/`expanded`/`auto`; default `folded`) to seed controller state in the method graph.
  - VS Code: `pipelex.graph.showControllers` now defaults to `true` (set to `false` to hide).
  - Upgrade `@pipelex/mthds-ui` to `0.6.3` to support initial fold mode.
  - `plxt` 0.4.0: bundle MTHDS schema v0.27.0 with `PipeStructure` blueprint, PDF options `render_js` and `include_raw_html`, and `xhigh` reasoning effort.

- **Bug Fixes**
  - Method graph now respects `graph.direction`, `graph.showControllers`, and `graph.foldMode` on first open by waiting for config and remounting `GraphViewer` when the panel switches to a different file.

<sup>Written for commit 4c863af56ecbdb88dc788c0143f422e652b8cad5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

