### PR TITLE
Release extension v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Pipelex IDE Extension and `plxt` CLI Changelog
 
+## [0.7.1] - 2026-05-13
+
+### Changed
+- Upgrade @pipelex/mthds-ui to v0.6.4
+
 ## [0.7.0] - 2026-05-12
 
 ### Added

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "pipelex",
   "displayName": "Pipelex",
   "description": "Pipelex extension for the MTHDS language",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "repository": {
     "url": "https://github.com/Pipelex/vscode-pipelex"
   },
@@ -763,7 +763,7 @@
   },
   "dependencies": {
     "@pipelex/lsp": "portal:../../js/lsp",
-    "@pipelex/mthds-ui": "npm:0.6.3",
+    "@pipelex/mthds-ui": "npm:0.6.4",
     "deep-equal": "^2.2.3",
     "encoding": "^0.1.13",
     "fast-glob": "^3.3.2",

--- a/editors/vscode/yarn.lock
+++ b/editors/vscode/yarn.lock
@@ -483,9 +483,9 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@pipelex/mthds-ui@npm:0.6.3":
-  version: 0.6.3
-  resolution: "@pipelex/mthds-ui@npm:0.6.3"
+"@pipelex/mthds-ui@npm:0.6.4":
+  version: 0.6.4
+  resolution: "@pipelex/mthds-ui@npm:0.6.4"
   dependencies:
     "@xyflow/react": "npm:^12"
     dompurify: "npm:^3.3.3"
@@ -501,7 +501,7 @@ __metadata:
       optional: true
     shiki:
       optional: true
-  checksum: 8cb2772cf19a83501e34c13e362eae5ff5b005802fbfe93345d4dabe88e597cc5707bb940f8ad2e544d3f46aa6085cc52749f29b880962f7a4ded6b914256466
+  checksum: 442a12d45354e95f4ba07572ce13e6169a49f9c2447a2567074735841791caf3bbaed6d45d636417b10ba112a282c5502343b6edbcaa9ca9ffd1db0f64087663
   languageName: node
   linkType: hard
 
@@ -3471,7 +3471,7 @@ __metadata:
   resolution: "pipelex@workspace:."
   dependencies:
     "@pipelex/lsp": "portal:../../js/lsp"
-    "@pipelex/mthds-ui": "npm:0.6.3"
+    "@pipelex/mthds-ui": "npm:0.6.4"
     "@rollup/plugin-commonjs": "npm:^25.0.7"
     "@rollup/plugin-node-resolve": "npm:^15.2.3"
     "@rollup/plugin-replace": "npm:^5.0.5"


### PR DESCRIPTION
## Summary
- Bump extension version to 0.7.1
- Upgrade @pipelex/mthds-ui from 0.6.3 to 0.6.4

## Test plan
- [ ] CI passes (fmt, clippy, tests, WASM check)
- [ ] Merge to main triggers auto-tag and publishing to VS Code Marketplace + Open VSX

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release the VS Code extension v0.7.1, upgrading `@pipelex/mthds-ui` to `0.6.4` to pull in recent UI fixes and improvements.

<sup>Written for commit c5fc288a28d64e3d96baa8fe8655447c765e5977. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

