### PR TITLE
Add --schema-path to plxt lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,6 +1589,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/pipelex-cli/Cargo.toml
+++ b/crates/pipelex-cli/Cargo.toml
@@ -12,6 +12,7 @@ repository   = { workspace = true }
 [features]
 default = ["completions", "lint", "lsp", "rustls-tls"]
 lint = [
+  "dep:url",
   "reqwest",
   "taplo-cli/lint",
   "taplo-common/reqwest",
@@ -32,6 +33,7 @@ anyhow  = { workspace = true }
 clap    = { workspace = true, features = ["derive", "cargo", "env", "default"] }
 toml    = { version = "0.7" }
 tracing = { workspace = true }
+url     = { workspace = true, optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 lsp-async-stub = { version = "0.7.0", path = "../lsp-async-stub", features = [

--- a/crates/pipelex-cli/src/args.rs
+++ b/crates/pipelex-cli/src/args.rs
@@ -31,7 +31,7 @@ pub enum PlxtCommand {
     /// Lint TOML documents.
     #[clap(visible_aliases = &["check", "validate"])]
     #[cfg(feature = "lint")]
-    Lint(LintCommand),
+    Lint(PlxtLintCommand),
 
     /// Format TOML documents.
     ///
@@ -70,6 +70,21 @@ pub enum PlxtConfigCommand {
     Schema,
     /// Print the path of the resolved configuration file.
     Which,
+}
+
+/// Pipelex-flavored lint command: wraps taplo's `LintCommand` and adds a path-based schema override.
+#[cfg(feature = "lint")]
+#[derive(Clone, clap::Args)]
+pub struct PlxtLintCommand {
+    #[clap(flatten)]
+    pub inner: LintCommand,
+
+    /// Path to a JSON schema file to use for validation, overriding the normal schema resolution rules.
+    ///
+    /// The path can be relative (resolved against the current working directory) or absolute.
+    /// Mutually exclusive with `--schema`.
+    #[clap(long, value_name = "PATH", conflicts_with = "schema")]
+    pub schema_path: Option<PathBuf>,
 }
 
 /// Pipelex-specific GeneralArgs.

--- a/crates/pipelex-cli/src/commands/mod.rs
+++ b/crates/pipelex-cli/src/commands/mod.rs
@@ -10,6 +10,29 @@ mod config;
 #[cfg(feature = "lsp")]
 mod lsp;
 
+#[cfg(feature = "lint")]
+use anyhow::{anyhow, Context};
+#[cfg(feature = "lint")]
+use std::path::Path;
+#[cfg(feature = "lint")]
+use url::Url;
+
+#[cfg(feature = "lint")]
+fn resolve_schema_path(path: &Path) -> Result<Url, anyhow::Error> {
+    let absolute = path.canonicalize().with_context(|| {
+        format!(
+            "could not resolve --schema-path {} (file not found or unreadable)",
+            path.display()
+        )
+    })?;
+    Url::from_file_path(&absolute).map_err(|_| {
+        anyhow!(
+            "could not convert schema path {} to a file:// URL",
+            absolute.display()
+        )
+    })
+}
+
 impl<E: Environment> PlxtCli<E> {
     pub async fn execute(&mut self, args: PlxtArgs) -> Result<(), anyhow::Error> {
         self.colors = match args.colors {
@@ -57,13 +80,17 @@ impl<E: Environment> PlxtCli<E> {
             }
             #[cfg(feature = "lint")]
             PlxtCommand::Lint(cmd) => {
+                let mut lint_cmd = cmd.inner;
+                if let Some(schema_path) = cmd.schema_path {
+                    lint_cmd.schema = Some(resolve_schema_path(&schema_path)?);
+                }
                 // Enable compact one-line error output for plxt when not verbose
                 self.inner.set_compact(!args.verbose);
                 let taplo_args = TaploArgs {
                     colors: args.colors,
                     verbose: args.verbose,
                     log_spans: args.log_spans,
-                    cmd: TaploCommand::Lint(cmd),
+                    cmd: TaploCommand::Lint(lint_cmd),
                 };
                 self.inner.execute(taplo_args).await
             }

--- a/crates/pipelex-cli/src/commands/mod.rs
+++ b/crates/pipelex-cli/src/commands/mod.rs
@@ -11,20 +11,25 @@ mod config;
 mod lsp;
 
 #[cfg(feature = "lint")]
-use anyhow::{anyhow, Context};
+use anyhow::anyhow;
 #[cfg(feature = "lint")]
 use std::path::Path;
 #[cfg(feature = "lint")]
 use url::Url;
 
 #[cfg(feature = "lint")]
-fn resolve_schema_path(path: &Path) -> Result<Url, anyhow::Error> {
-    let absolute = path.canonicalize().with_context(|| {
-        format!(
-            "could not resolve --schema-path {} (file not found or unreadable)",
-            path.display()
-        )
-    })?;
+fn resolve_schema_path<E: Environment>(env: &E, path: &Path) -> Result<Url, anyhow::Error> {
+    let absolute = if env.is_absolute(path) {
+        path.to_path_buf()
+    } else {
+        let cwd = env.cwd_normalized().ok_or_else(|| {
+            anyhow!(
+                "could not determine working directory to resolve --schema-path {}",
+                path.display()
+            )
+        })?;
+        cwd.join(path)
+    };
     Url::from_file_path(&absolute).map_err(|_| {
         anyhow!(
             "could not convert schema path {} to a file:// URL",
@@ -82,7 +87,7 @@ impl<E: Environment> PlxtCli<E> {
             PlxtCommand::Lint(cmd) => {
                 let mut lint_cmd = cmd.inner;
                 if let Some(schema_path) = cmd.schema_path {
-                    lint_cmd.schema = Some(resolve_schema_path(&schema_path)?);
+                    lint_cmd.schema = Some(resolve_schema_path(&self.env, &schema_path)?);
                 }
                 // Enable compact one-line error output for plxt when not verbose
                 self.inner.set_compact(!args.verbose);

--- a/crates/pipelex-cli/tests/schema_path.rs
+++ b/crates/pipelex-cli/tests/schema_path.rs
@@ -92,7 +92,8 @@ fn schema_path_missing_file_errors_cleanly() {
     assert!(!output.status.success(), "expected non-zero exit");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("could not resolve --schema-path"),
-        "expected resolve error in stderr, got: {stderr}"
+        stderr.contains("failed to load schema")
+            && stderr.contains("file:///definitely/does/not/exist.json"),
+        "expected schema-load failure for the file:// URL in stderr, got: {stderr}"
     );
 }

--- a/crates/pipelex-cli/tests/schema_path.rs
+++ b/crates/pipelex-cli/tests/schema_path.rs
@@ -1,0 +1,98 @@
+use std::process::Command;
+
+fn plxt_cmd() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_plxt"))
+}
+
+const VALID_FILE: &str = "../../test-data/mthds/lint/valid.mthds";
+const INVALID_FILE: &str = "../../test-data/mthds/lint/invalid_schema.mthds";
+const MTHDS_SCHEMA: &str = "../taplo-common/schemas/mthds_schema.json";
+
+#[test]
+fn schema_path_valid_file_passes() {
+    let output = plxt_cmd()
+        .args([
+            "lint",
+            "--quiet",
+            "--no-auto-config",
+            "--schema-path",
+            MTHDS_SCHEMA,
+            VALID_FILE,
+        ])
+        .output()
+        .expect("failed to run plxt");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "expected exit 0, got status {:?}, stderr: {stderr}",
+        output.status.code()
+    );
+    assert!(stderr.is_empty(), "expected no stderr, got: {stderr}");
+}
+
+#[test]
+fn schema_path_invalid_file_fails_with_schema_error() {
+    let output = plxt_cmd()
+        .args([
+            "lint",
+            "--quiet",
+            "--no-auto-config",
+            "--schema-path",
+            MTHDS_SCHEMA,
+            INVALID_FILE,
+        ])
+        .output()
+        .expect("failed to run plxt");
+
+    assert!(!output.status.success(), "expected non-zero exit");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("error[schema]"),
+        "expected schema diagnostic in stderr, got: {stderr}"
+    );
+}
+
+#[test]
+fn schema_and_schema_path_are_mutually_exclusive() {
+    let output = plxt_cmd()
+        .args([
+            "lint",
+            "--no-auto-config",
+            "--schema",
+            "http://example.com/x.json",
+            "--schema-path",
+            "/tmp/x.json",
+            VALID_FILE,
+        ])
+        .output()
+        .expect("failed to run plxt");
+
+    assert!(!output.status.success(), "expected non-zero exit");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot be used with"),
+        "expected clap conflict error, got: {stderr}"
+    );
+}
+
+#[test]
+fn schema_path_missing_file_errors_cleanly() {
+    let output = plxt_cmd()
+        .args([
+            "lint",
+            "--no-auto-config",
+            "--schema-path",
+            "/definitely/does/not/exist.json",
+            VALID_FILE,
+        ])
+        .output()
+        .expect("failed to run plxt");
+
+    assert!(!output.status.success(), "expected non-zero exit");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("could not resolve --schema-path"),
+        "expected resolve error in stderr, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
- Add `--schema-path <PATH>` to `plxt lint` for overriding schema resolution with a local JSON schema file (relative or absolute path; canonicalized and converted to a `file://` URL before being fed into taplo's existing `--schema` flow)
- New flag is mutually exclusive with the existing `--schema <URL>`; conflict and missing-file cases produce clear errors
- Purely additive on the plxt side — no upstream taplo crates touched

## Test plan
- [x] `make check` green (fmt, clippy `-D warnings`, all Rust tests, vitest, WASM check)
- [x] `cargo test -p pipelex-cli --test schema_path` — 4 new tests pass (valid file, invalid file, `--schema`/`--schema-path` conflict, missing path)
- [x] Manual: `plxt lint --schema-path crates/taplo-common/schemas/mthds_schema.json test-data/mthds/pipe-definitions.mthds` surfaces real schema errors
- [x] Verified `url` is gated behind the `lint` feature: `cargo tree -p pipelex-cli --no-default-features --features completions --depth 1` no longer lists `url`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `--schema-path <PATH>` to `plxt lint` to validate with a local JSON schema file. The path is resolved via the CLI `Environment` (cwd + absolute check) and converted to a `file://` URL, then passed through taplo’s existing `--schema` flow.

- New Features
  - `--schema-path <PATH>` supports relative or absolute paths; resolution uses the `Environment` (works with virtual/non-native FS).
  - Mutually exclusive with `--schema`; conflicts and missing files show clear, targeted errors.
  - Implemented in `pipelex-cli` by wrapping taplo’s `LintCommand`; no upstream taplo changes.

- Dependencies
  - Added optional `url` (workspace) gated behind the `lint` feature.

<sup>Written for commit 6b9cd1921d137196bc9e154ea47fc0fad49193f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

