### PR TITLE
Release v0.8.0: extension v0.8.0 + plxt v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Pipelex IDE Extension and `plxt` CLI Changelog
 
+## [0.8.0] - 2026-05-20
+
+### Added
+- `plxt lint --schema-path <path>` overrides the resolved schema with a local file, so MTHDS bundles can be linted against an in-development schema without publishing it (plxt 0.5.0)
+- Method graph panel now detects outdated `pipelex-agent` (< 0.29.0) and surfaces a targeted upgrade message with install commands instead of a generic error
+
+### Changed
+- Method graph panel passes `--format json` to `pipelex-agent validate bundle`; this is required by `pipelex-agent` 0.29.0+, which now defaults to markdown output
+- Upgrade @pipelex/mthds-ui to v0.6.5
+
 ## [0.7.1] - 2026-05-13
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,6 +1589,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,7 +1574,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipelex-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-ctrlc",

--- a/crates/pipelex-cli/Cargo.toml
+++ b/crates/pipelex-cli/Cargo.toml
@@ -12,6 +12,7 @@ repository   = { workspace = true }
 [features]
 default = ["completions", "lint", "lsp", "rustls-tls"]
 lint = [
+  "dep:url",
   "reqwest",
   "taplo-cli/lint",
   "taplo-common/reqwest",
@@ -32,6 +33,7 @@ anyhow  = { workspace = true }
 clap    = { workspace = true, features = ["derive", "cargo", "env", "default"] }
 toml    = { version = "0.7" }
 tracing = { workspace = true }
+url     = { workspace = true, optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 lsp-async-stub = { version = "0.7.0", path = "../lsp-async-stub", features = [

--- a/crates/pipelex-cli/Cargo.toml
+++ b/crates/pipelex-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "pipelex-cli"
 description  = "Pipelex Tools CLI (plxt) - wraps taplo-cli with MTHDS support"
-version      = "0.4.0"
+version      = "0.5.0"
 rust-version = { workspace = true }
 authors      = { workspace = true }
 edition      = { workspace = true }

--- a/crates/pipelex-cli/src/args.rs
+++ b/crates/pipelex-cli/src/args.rs
@@ -31,7 +31,7 @@ pub enum PlxtCommand {
     /// Lint TOML documents.
     #[clap(visible_aliases = &["check", "validate"])]
     #[cfg(feature = "lint")]
-    Lint(LintCommand),
+    Lint(PlxtLintCommand),
 
     /// Format TOML documents.
     ///
@@ -70,6 +70,21 @@ pub enum PlxtConfigCommand {
     Schema,
     /// Print the path of the resolved configuration file.
     Which,
+}
+
+/// Pipelex-flavored lint command: wraps taplo's `LintCommand` and adds a path-based schema override.
+#[cfg(feature = "lint")]
+#[derive(Clone, clap::Args)]
+pub struct PlxtLintCommand {
+    #[clap(flatten)]
+    pub inner: LintCommand,
+
+    /// Path to a JSON schema file to use for validation, overriding the normal schema resolution rules.
+    ///
+    /// The path can be relative (resolved against the current working directory) or absolute.
+    /// Mutually exclusive with `--schema`.
+    #[clap(long, value_name = "PATH", conflicts_with = "schema")]
+    pub schema_path: Option<PathBuf>,
 }
 
 /// Pipelex-specific GeneralArgs.

--- a/crates/pipelex-cli/src/commands/mod.rs
+++ b/crates/pipelex-cli/src/commands/mod.rs
@@ -10,6 +10,29 @@ mod config;
 #[cfg(feature = "lsp")]
 mod lsp;
 
+#[cfg(feature = "lint")]
+use anyhow::{anyhow, Context};
+#[cfg(feature = "lint")]
+use std::path::Path;
+#[cfg(feature = "lint")]
+use url::Url;
+
+#[cfg(feature = "lint")]
+fn resolve_schema_path(path: &Path) -> Result<Url, anyhow::Error> {
+    let absolute = path.canonicalize().with_context(|| {
+        format!(
+            "could not resolve --schema-path {} (file not found or unreadable)",
+            path.display()
+        )
+    })?;
+    Url::from_file_path(&absolute).map_err(|_| {
+        anyhow!(
+            "could not convert schema path {} to a file:// URL",
+            absolute.display()
+        )
+    })
+}
+
 impl<E: Environment> PlxtCli<E> {
     pub async fn execute(&mut self, args: PlxtArgs) -> Result<(), anyhow::Error> {
         self.colors = match args.colors {
@@ -57,13 +80,17 @@ impl<E: Environment> PlxtCli<E> {
             }
             #[cfg(feature = "lint")]
             PlxtCommand::Lint(cmd) => {
+                let mut lint_cmd = cmd.inner;
+                if let Some(schema_path) = cmd.schema_path {
+                    lint_cmd.schema = Some(resolve_schema_path(&schema_path)?);
+                }
                 // Enable compact one-line error output for plxt when not verbose
                 self.inner.set_compact(!args.verbose);
                 let taplo_args = TaploArgs {
                     colors: args.colors,
                     verbose: args.verbose,
                     log_spans: args.log_spans,
-                    cmd: TaploCommand::Lint(cmd),
+                    cmd: TaploCommand::Lint(lint_cmd),
                 };
                 self.inner.execute(taplo_args).await
             }

--- a/crates/pipelex-cli/src/commands/mod.rs
+++ b/crates/pipelex-cli/src/commands/mod.rs
@@ -11,20 +11,25 @@ mod config;
 mod lsp;
 
 #[cfg(feature = "lint")]
-use anyhow::{anyhow, Context};
+use anyhow::anyhow;
 #[cfg(feature = "lint")]
 use std::path::Path;
 #[cfg(feature = "lint")]
 use url::Url;
 
 #[cfg(feature = "lint")]
-fn resolve_schema_path(path: &Path) -> Result<Url, anyhow::Error> {
-    let absolute = path.canonicalize().with_context(|| {
-        format!(
-            "could not resolve --schema-path {} (file not found or unreadable)",
-            path.display()
-        )
-    })?;
+fn resolve_schema_path<E: Environment>(env: &E, path: &Path) -> Result<Url, anyhow::Error> {
+    let absolute = if env.is_absolute(path) {
+        path.to_path_buf()
+    } else {
+        let cwd = env.cwd_normalized().ok_or_else(|| {
+            anyhow!(
+                "could not determine working directory to resolve --schema-path {}",
+                path.display()
+            )
+        })?;
+        cwd.join(path)
+    };
     Url::from_file_path(&absolute).map_err(|_| {
         anyhow!(
             "could not convert schema path {} to a file:// URL",
@@ -82,7 +87,7 @@ impl<E: Environment> PlxtCli<E> {
             PlxtCommand::Lint(cmd) => {
                 let mut lint_cmd = cmd.inner;
                 if let Some(schema_path) = cmd.schema_path {
-                    lint_cmd.schema = Some(resolve_schema_path(&schema_path)?);
+                    lint_cmd.schema = Some(resolve_schema_path(&self.env, &schema_path)?);
                 }
                 // Enable compact one-line error output for plxt when not verbose
                 self.inner.set_compact(!args.verbose);

--- a/crates/pipelex-cli/tests/schema_path.rs
+++ b/crates/pipelex-cli/tests/schema_path.rs
@@ -92,7 +92,8 @@ fn schema_path_missing_file_errors_cleanly() {
     assert!(!output.status.success(), "expected non-zero exit");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("could not resolve --schema-path"),
-        "expected resolve error in stderr, got: {stderr}"
+        stderr.contains("failed to load schema")
+            && stderr.contains("file:///definitely/does/not/exist.json"),
+        "expected schema-load failure for the file:// URL in stderr, got: {stderr}"
     );
 }

--- a/crates/pipelex-cli/tests/schema_path.rs
+++ b/crates/pipelex-cli/tests/schema_path.rs
@@ -1,0 +1,98 @@
+use std::process::Command;
+
+fn plxt_cmd() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_plxt"))
+}
+
+const VALID_FILE: &str = "../../test-data/mthds/lint/valid.mthds";
+const INVALID_FILE: &str = "../../test-data/mthds/lint/invalid_schema.mthds";
+const MTHDS_SCHEMA: &str = "../taplo-common/schemas/mthds_schema.json";
+
+#[test]
+fn schema_path_valid_file_passes() {
+    let output = plxt_cmd()
+        .args([
+            "lint",
+            "--quiet",
+            "--no-auto-config",
+            "--schema-path",
+            MTHDS_SCHEMA,
+            VALID_FILE,
+        ])
+        .output()
+        .expect("failed to run plxt");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "expected exit 0, got status {:?}, stderr: {stderr}",
+        output.status.code()
+    );
+    assert!(stderr.is_empty(), "expected no stderr, got: {stderr}");
+}
+
+#[test]
+fn schema_path_invalid_file_fails_with_schema_error() {
+    let output = plxt_cmd()
+        .args([
+            "lint",
+            "--quiet",
+            "--no-auto-config",
+            "--schema-path",
+            MTHDS_SCHEMA,
+            INVALID_FILE,
+        ])
+        .output()
+        .expect("failed to run plxt");
+
+    assert!(!output.status.success(), "expected non-zero exit");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("error[schema]"),
+        "expected schema diagnostic in stderr, got: {stderr}"
+    );
+}
+
+#[test]
+fn schema_and_schema_path_are_mutually_exclusive() {
+    let output = plxt_cmd()
+        .args([
+            "lint",
+            "--no-auto-config",
+            "--schema",
+            "http://example.com/x.json",
+            "--schema-path",
+            "/tmp/x.json",
+            VALID_FILE,
+        ])
+        .output()
+        .expect("failed to run plxt");
+
+    assert!(!output.status.success(), "expected non-zero exit");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot be used with"),
+        "expected clap conflict error, got: {stderr}"
+    );
+}
+
+#[test]
+fn schema_path_missing_file_errors_cleanly() {
+    let output = plxt_cmd()
+        .args([
+            "lint",
+            "--no-auto-config",
+            "--schema-path",
+            "/definitely/does/not/exist.json",
+            VALID_FILE,
+        ])
+        .output()
+        .expect("failed to run plxt");
+
+    assert!(!output.status.success(), "expected non-zero exit");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("could not resolve --schema-path"),
+        "expected resolve error in stderr, got: {stderr}"
+    );
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "pipelex",
   "displayName": "Pipelex",
   "description": "Pipelex extension for the MTHDS language",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "repository": {
     "url": "https://github.com/Pipelex/vscode-pipelex"
   },
@@ -763,7 +763,7 @@
   },
   "dependencies": {
     "@pipelex/lsp": "portal:../../js/lsp",
-    "@pipelex/mthds-ui": "npm:0.6.4",
+    "@pipelex/mthds-ui": "npm:0.6.5",
     "deep-equal": "^2.2.3",
     "encoding": "^0.1.13",
     "fast-glob": "^3.3.2",

--- a/editors/vscode/src/pipelex/__tests__/agentCliVersion.test.ts
+++ b/editors/vscode/src/pipelex/__tests__/agentCliVersion.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock child_process.execFile so the probe is fully controllable.
+// The mock records each invocation so we can assert that cwd is forwarded
+// and that the per-cwd cache key isolates results across workspaces.
+type ExecFileCall = {
+    command: string;
+    args: readonly string[];
+    options: { cwd?: string };
+};
+
+const calls: ExecFileCall[] = [];
+let nextStdout = 'pipelex-agent 0.29.0\n';
+
+vi.mock('child_process', () => ({
+    execFile: (
+        command: string,
+        args: readonly string[],
+        options: { cwd?: string },
+        cb: (err: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+        calls.push({ command, args, options });
+        cb(null, nextStdout, '');
+    },
+}));
+
+import { getAgentCliVersion, clearAgentCliVersionCache } from '../validation/agentCliVersion';
+
+describe('getAgentCliVersion', () => {
+    beforeEach(() => {
+        clearAgentCliVersionCache();
+        calls.length = 0;
+    });
+
+    it('forwards cwd to execFile so uv resolves the right project env', async () => {
+        await getAgentCliVersion('uv', ['run', 'pipelex-agent'], '/workspace/a');
+        expect(calls).toHaveLength(1);
+        expect(calls[0].options.cwd).toBe('/workspace/a');
+        expect(calls[0].args).toEqual(['run', 'pipelex-agent', '--version']);
+    });
+
+    it('keys the cache by cwd so different workspaces probe independently', async () => {
+        nextStdout = 'pipelex-agent 0.29.0\n';
+        const a = await getAgentCliVersion('uv', ['run', 'pipelex-agent'], '/workspace/a');
+
+        nextStdout = 'pipelex-agent 0.28.0\n';
+        const b = await getAgentCliVersion('uv', ['run', 'pipelex-agent'], '/workspace/b');
+
+        expect(a).toEqual([0, 29, 0]);
+        expect(b).toEqual([0, 28, 0]);
+        expect(calls).toHaveLength(2);
+    });
+
+    it('reuses the cached probe for the same (command, args, cwd) triple', async () => {
+        nextStdout = 'pipelex-agent 0.29.0\n';
+        await getAgentCliVersion('uv', ['run', 'pipelex-agent'], '/workspace/a');
+        await getAgentCliVersion('uv', ['run', 'pipelex-agent'], '/workspace/a');
+        expect(calls).toHaveLength(1);
+    });
+});

--- a/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
+++ b/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
@@ -3,6 +3,7 @@ import * as crypto from 'crypto';
 import * as fs from 'fs';
 import { resolveCli } from '../validation/cliResolver';
 import { spawnCli, cancelAllInflight } from '../validation/processUtils';
+import { getAgentCliVersion, compareSemver, formatSemver, MIN_FORMAT_JSON_VERSION } from '../validation/agentCliVersion';
 import { extractJson } from '../validation/pipelexValidator';
 import type { ValidationFailure } from '../validation/types';
 import { findTableHeader } from '../validation/sourceLocator';
@@ -260,7 +261,10 @@ export class MethodGraphPanel implements vscode.Disposable {
         const showControllers = pipelexConfig.get<boolean>('graph.showControllers', true);
         const foldMode = pipelexConfig.get<string>('graph.foldMode', 'folded');
         const filePath = uri.fsPath;
-        const args = [...resolved.args, 'validate', 'bundle', filePath, '--view', '--direction', direction];
+        // pipelex-agent >= 0.29.0 defaults to markdown output and needs `--format json` to emit
+        // structured JSON. Always pass it; if the CLI predates 0.29.0 the invocation will fail
+        // and the catch block surfaces a targeted upgrade message.
+        const args = [...resolved.args, 'validate', 'bundle', filePath, '--view', '--direction', direction, '--format', 'json'];
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
         const cwd = workspaceFolder?.uri.fsPath;
 
@@ -294,6 +298,30 @@ export class MethodGraphPanel implements vscode.Disposable {
         } catch (err: any) {
             if (controller.signal.aborted) return;
             if (this.currentUri?.toString() !== uri.toString()) return;
+
+            // Before falling into the generic error paths, check whether the failure
+            // is just an outdated `pipelex-agent` that predates `--format json` (0.29.0).
+            const installedVersion = await getAgentCliVersion(resolved.command, resolved.args);
+            if (installedVersion && compareSemver(installedVersion, MIN_FORMAT_JSON_VERSION) < 0) {
+                if (controller.signal.aborted) return;
+                if (this.currentUri?.toString() !== uri.toString()) return;
+                this.output.appendLine(
+                    `pipelex-agent ${formatSemver(installedVersion)} is too old for the graph panel ` +
+                    `(needs ≥ ${formatSemver(MIN_FORMAT_JSON_VERSION)}).`
+                );
+                this.setHtml(messageHtml(
+                    'Update Pipelex',
+                    `Your installed <code>pipelex-agent</code> is <strong>${escapeHtml(formatSemver(installedVersion))}</strong>, ` +
+                    `but the method graph requires <strong>≥ ${escapeHtml(formatSemver(MIN_FORMAT_JSON_VERSION))}</strong> ` +
+                    `(the <code>--format json</code> option landed in that release).` +
+                    `</p><p>` +
+                    `Upgrade Pipelex and try again:<br>` +
+                    `<code>mthds runner setup pipelex</code> (mthds-managed install)<br>` +
+                    `<code>uv tool upgrade pipelex</code> (uv tool install)<br>` +
+                    `<code>uv pip install -U pipelex</code> or <code>pip install -U pipelex</code> (project virtualenv)`
+                ));
+                return;
+            }
 
             if (err.exitCode === 1 && err.stderr) {
                 const stderr = err.stderr as string;

--- a/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
+++ b/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
@@ -301,7 +301,7 @@ export class MethodGraphPanel implements vscode.Disposable {
 
             // Before falling into the generic error paths, check whether the failure
             // is just an outdated `pipelex-agent` that predates `--format json` (0.29.0).
-            const installedVersion = await getAgentCliVersion(resolved.command, resolved.args);
+            const installedVersion = await getAgentCliVersion(resolved.command, resolved.args, cwd);
             if (installedVersion && compareSemver(installedVersion, MIN_FORMAT_JSON_VERSION) < 0) {
                 if (controller.signal.aborted) return;
                 if (this.currentUri?.toString() !== uri.toString()) return;

--- a/editors/vscode/src/pipelex/validation/agentCliVersion.ts
+++ b/editors/vscode/src/pipelex/validation/agentCliVersion.ts
@@ -1,0 +1,60 @@
+import { execFile } from 'child_process';
+
+/**
+ * Probe `pipelex-agent --version` and return the parsed semver, or null if
+ * the probe fails or the output is unparseable. Cached per (command + args)
+ * for the lifetime of the extension host.
+ *
+ * Used to give actionable error messages when an installed `pipelex-agent`
+ * predates a feature the extension relies on (e.g. `--format json`, which
+ * landed in 0.29.0).
+ */
+
+export type Semver = readonly [number, number, number];
+
+/** First `pipelex-agent` version that accepts `validate bundle --format json`. */
+export const MIN_FORMAT_JSON_VERSION: Semver = [0, 29, 0];
+
+const cache = new Map<string, Promise<Semver | null>>();
+
+const VERSION_RE = /pipelex-agent\s+(\d+)\.(\d+)\.(\d+)/;
+
+export function compareSemver(a: Semver, b: Semver): number {
+    for (let i = 0; i < 3; i++) {
+        if (a[i] !== b[i]) return a[i] - b[i];
+    }
+    return 0;
+}
+
+export function formatSemver(v: Semver): string {
+    return `${v[0]}.${v[1]}.${v[2]}`;
+}
+
+export function getAgentCliVersion(command: string, baseArgs: string[]): Promise<Semver | null> {
+    const key = JSON.stringify([command, baseArgs]);
+    const cached = cache.get(key);
+    if (cached) return cached;
+
+    const probe = new Promise<Semver | null>((resolve) => {
+        execFile(command, [...baseArgs, '--version'], { timeout: 5000, maxBuffer: 64 * 1024 }, (err, stdout, stderr) => {
+            if (err) {
+                resolve(null);
+                return;
+            }
+            const match = (stdout || stderr || '').match(VERSION_RE);
+            if (!match) {
+                resolve(null);
+                return;
+            }
+            resolve([Number(match[1]), Number(match[2]), Number(match[3])]);
+        });
+    });
+
+    cache.set(key, probe);
+    return probe;
+}
+
+/** Test/diagnostic helper — clears the in-memory version cache. */
+export function clearAgentCliVersionCache(): void {
+    cache.clear();
+}

--- a/editors/vscode/src/pipelex/validation/agentCliVersion.ts
+++ b/editors/vscode/src/pipelex/validation/agentCliVersion.ts
@@ -30,13 +30,17 @@ export function formatSemver(v: Semver): string {
     return `${v[0]}.${v[1]}.${v[2]}`;
 }
 
-export function getAgentCliVersion(command: string, baseArgs: string[]): Promise<Semver | null> {
-    const key = JSON.stringify([command, baseArgs]);
+export function getAgentCliVersion(command: string, baseArgs: string[], cwd?: string): Promise<Semver | null> {
+    // Include cwd in the cache key: for `uv run pipelex-agent`, the resolved
+    // project environment (and therefore the agent version) depends on the
+    // working directory, so the same command+args can map to different
+    // versions across workspace folders in a multi-root workspace.
+    const key = JSON.stringify([command, baseArgs, cwd ?? null]);
     const cached = cache.get(key);
     if (cached) return cached;
 
     const probe = new Promise<Semver | null>((resolve) => {
-        execFile(command, [...baseArgs, '--version'], { timeout: 5000, maxBuffer: 64 * 1024 }, (err, stdout, stderr) => {
+        execFile(command, [...baseArgs, '--version'], { cwd, timeout: 5000, maxBuffer: 64 * 1024 }, (err, stdout, stderr) => {
             if (err) {
                 resolve(null);
                 return;

--- a/editors/vscode/yarn.lock
+++ b/editors/vscode/yarn.lock
@@ -483,9 +483,9 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@pipelex/mthds-ui@npm:0.6.4":
-  version: 0.6.4
-  resolution: "@pipelex/mthds-ui@npm:0.6.4"
+"@pipelex/mthds-ui@npm:0.6.5":
+  version: 0.6.5
+  resolution: "@pipelex/mthds-ui@npm:0.6.5"
   dependencies:
     "@xyflow/react": "npm:^12"
     dompurify: "npm:^3.3.3"
@@ -501,7 +501,7 @@ __metadata:
       optional: true
     shiki:
       optional: true
-  checksum: 442a12d45354e95f4ba07572ce13e6169a49f9c2447a2567074735841791caf3bbaed6d45d636417b10ba112a282c5502343b6edbcaa9ca9ffd1db0f64087663
+  checksum: 4d3baaa143ff5c805822413e618d00e3c2c1e6e176893b37e0208e73966268b893aab674020efcc3b39a3274898dbe9ef1eacb0332b5b8c7fa05a9d2ea725c6e
   languageName: node
   linkType: hard
 
@@ -3471,7 +3471,7 @@ __metadata:
   resolution: "pipelex@workspace:."
   dependencies:
     "@pipelex/lsp": "portal:../../js/lsp"
-    "@pipelex/mthds-ui": "npm:0.6.4"
+    "@pipelex/mthds-ui": "npm:0.6.5"
     "@rollup/plugin-commonjs": "npm:^25.0.7"
     "@rollup/plugin-node-resolve": "npm:^15.2.3"
     "@rollup/plugin-replace": "npm:^5.0.5"


### PR DESCRIPTION
## Extension 0.8.0

### Added
- Method graph panel now detects outdated \`pipelex-agent\` (< 0.29.0) and surfaces a targeted upgrade message with install commands instead of a generic error

### Changed
- Method graph panel passes \`--format json\` to \`pipelex-agent validate bundle\`; required by \`pipelex-agent\` 0.29.0+, which now defaults to markdown output
- Upgrade \`@pipelex/mthds-ui\` to v0.6.5

## plxt CLI 0.5.0

### Added
- \`plxt lint --schema-path <path>\` overrides the resolved schema with a local file, so MTHDS bundles can be linted against an in-development schema without publishing it

## Release flow

Merging to \`main\` triggers CI auto-tagging (\`pipelex-vscode-ext/v0.8.0\` and \`plxt-cli/v0.5.0\`) and publishes to VS Code Marketplace, Open VSX, and PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.8.0 of the VS Code extension and v0.5.0 of the `plxt` CLI. Adds a local schema override for `plxt lint` and improves the Method Graph with JSON output and accurate per-workspace upgrade guidance for older `pipelex-agent` installs.

- **New Features**
  - `plxt lint --schema-path <path>` lets you lint against a local JSON schema (relative or absolute). Conflicts with `--schema`.
  - Method Graph now calls `pipelex-agent validate bundle ... --format json` for structured output.
  - If `pipelex-agent` < 0.29.0 is detected, the panel shows a targeted upgrade message with install commands. Version probing forwards the workspace `cwd` and caches per folder for correct results with `uv`.

- **Dependencies**
  - Bump `@pipelex/mthds-ui` to `0.6.5`.

<sup>Written for commit d858c488cf83627e1f2e483b68e92246c4f8ba42. Summary will update on new commits. <a href="https://cubic.dev/pr/Pipelex/vscode-pipelex/pull/46?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

