### PR TITLE
Release v0.9.0: extension v0.9.0 + plxt v0.6.0

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -85,6 +85,11 @@ jobs:
       - name: Extension NPM Install
         run: yarn
         working-directory: editors/vscode
+        env:
+          # @vscode/test-web pulls @playwright/browser-chromium, whose postinstall downloads a
+          # ~173 MiB browser. This job only packages the extension (no browser tests run here),
+          # and that download was hanging the install step. Skip the browser binary download.
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
       - name: Install vsce
         run: npm install -g @vscode/vsce
       - name: Package Extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Pipelex IDE Extension and `plxt` CLI Changelog
 
+## [0.9.0] - 2026-05-31
+
+### Changed
+- Update bundled MTHDS schema to v0.31.0 — adds the `PipeSignature` blueprint (a contract-only pipe that declares inputs and output with no implementation, so an in-progress pipeline can be dry-run validated before all its pipes are implemented) and a `PipeType` enum (plxt 0.6.0)
+
 ## [0.8.0] - 2026-05-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,7 +1574,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipelex-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-ctrlc",

--- a/crates/pipelex-cli/Cargo.toml
+++ b/crates/pipelex-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "pipelex-cli"
 description  = "Pipelex Tools CLI (plxt) - wraps taplo-cli with MTHDS support"
-version      = "0.5.0"
+version      = "0.6.0"
 rust-version = { workspace = true }
 authors      = { workspace = true }
 edition      = { workspace = true }

--- a/crates/taplo-common/schemas/mthds_schema.json
+++ b/crates/taplo-common/schemas/mthds_schema.json
@@ -99,6 +99,9 @@
               },
               {
                 "$ref": "#/definitions/PipeSequenceBlueprint"
+              },
+              {
+                "$ref": "#/definitions/PipeSignatureBlueprint"
               }
             ]
           },
@@ -1650,6 +1653,61 @@
       "title": "PipeSequenceBlueprint",
       "type": "object"
     },
+    "PipeSignatureBlueprint": {
+      "additionalProperties": false,
+      "description": "Contract-only pipe blueprint.\n\nA `PipeSignature` declares inputs and output but has no implementation. It exists so\nthat an in-progress pipeline can be validated (dry-run mocks the declared output)\nbefore all its pipes are implemented.",
+      "properties": {
+        "type": {
+          "default": "PipeSignature",
+          "title": "Type",
+          "type": "string",
+          "enum": [
+            "PipeSignature"
+          ]
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "inputs": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inputs"
+        },
+        "output": {
+          "title": "Output",
+          "type": "string"
+        },
+        "signature_for": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PipeType"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Intended downstream pipe type when this signature is implemented (optional hint for agents)."
+        }
+      },
+      "required": [
+        "description",
+        "output"
+      ],
+      "title": "PipeSignatureBlueprint",
+      "type": "object"
+    },
     "PipeStructureBlueprint": {
       "additionalProperties": false,
       "properties": {
@@ -1709,6 +1767,24 @@
       ],
       "title": "PipeStructureBlueprint",
       "type": "object"
+    },
+    "PipeType": {
+      "enum": [
+        "PipeFunc",
+        "PipeImgGen",
+        "PipeCompose",
+        "PipeLLM",
+        "PipeExtract",
+        "PipeSearch",
+        "PipeStructure",
+        "PipeBatch",
+        "PipeCondition",
+        "PipeParallel",
+        "PipeSequence",
+        "PipeSignature"
+      ],
+      "title": "PipeType",
+      "type": "string"
     },
     "PromptImageDetail": {
       "enum": [
@@ -1987,7 +2063,7 @@
     }
   },
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "$comment": "Generated from PipelexBundleBlueprint v0.27.0. Do not edit manually.",
+  "$comment": "Generated from PipelexBundleBlueprint v0.31.0. Do not edit manually.",
   "x-taplo": {
     "initKeys": [
       "domain"

--- a/crates/taplo-common/schemas/mthds_schema.json
+++ b/crates/taplo-common/schemas/mthds_schema.json
@@ -789,7 +789,8 @@
         "output",
         "branch_pipe_code",
         "input_list_name",
-        "input_item_name"
+        "input_item_name",
+        "type"
       ],
       "title": "PipeBatchBlueprint",
       "type": "object"
@@ -857,7 +858,8 @@
       },
       "required": [
         "description",
-        "output"
+        "output",
+        "type"
       ],
       "title": "PipeComposeBlueprint",
       "type": "object"
@@ -955,7 +957,8 @@
         "description",
         "output",
         "default_outcome",
-        "outcomes"
+        "outcomes",
+        "type"
       ],
       "title": "PipeConditionBlueprint",
       "type": "object"
@@ -1087,7 +1090,8 @@
       },
       "required": [
         "description",
-        "output"
+        "output",
+        "type"
       ],
       "title": "PipeExtractBlueprint",
       "type": "object"
@@ -1135,7 +1139,8 @@
       "required": [
         "description",
         "output",
-        "function_name"
+        "function_name",
+        "type"
       ],
       "title": "PipeFuncBlueprint",
       "type": "object"
@@ -1275,7 +1280,8 @@
       "required": [
         "description",
         "output",
-        "prompt"
+        "prompt",
+        "type"
       ],
       "title": "PipeImgGenBlueprint",
       "type": "object"
@@ -1388,7 +1394,8 @@
       },
       "required": [
         "description",
-        "output"
+        "output",
+        "type"
       ],
       "title": "PipeLLMBlueprint",
       "type": "object"
@@ -1455,7 +1462,8 @@
       "required": [
         "description",
         "output",
-        "branches"
+        "branches",
+        "type"
       ],
       "title": "PipeParallelBlueprint",
       "type": "object"
@@ -1598,7 +1606,8 @@
       "required": [
         "description",
         "output",
-        "prompt"
+        "prompt",
+        "type"
       ],
       "title": "PipeSearchBlueprint",
       "type": "object"
@@ -1648,7 +1657,8 @@
       "required": [
         "description",
         "output",
-        "steps"
+        "steps",
+        "type"
       ],
       "title": "PipeSequenceBlueprint",
       "type": "object"
@@ -1703,7 +1713,8 @@
       },
       "required": [
         "description",
-        "output"
+        "output",
+        "type"
       ],
       "title": "PipeSignatureBlueprint",
       "type": "object"
@@ -1763,7 +1774,8 @@
       },
       "required": [
         "description",
-        "output"
+        "output",
+        "type"
       ],
       "title": "PipeStructureBlueprint",
       "type": "object"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "pipelex",
   "displayName": "Pipelex",
   "description": "Pipelex extension for the MTHDS language",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "repository": {
     "url": "https://github.com/Pipelex/vscode-pipelex"
   },


### PR DESCRIPTION
## Summary

Release cut for the bundled MTHDS schema update.

| Component | Old → New |
|---|---|
| VS Code extension | 0.8.0 → **0.9.0** |
| plxt CLI | 0.5.0 → **0.6.0** |

## Changes

- **Update bundled MTHDS schema to v0.31.0** (`crates/taplo-common/schemas/mthds_schema.json`):
  - Adds the `PipeSignature` blueprint — a contract-only pipe that declares inputs and output with no implementation, so an in-progress pipeline can be dry-run validated (mocked output) before all its pipes are implemented.
  - Adds a `PipeType` enum.
- Schema is `include_str!`-embedded into `taplo-common`, so it ships in both the extension (via `pipelex-wasm`/`pipelex-lsp`) and the CLI (`pipelex-cli` → PyPI).

## Validation

- `cargo check -p pipelex-cli` ✅
- `cargo check -p pipelex-wasm --target wasm32-unknown-unknown` ✅

## Release flow

Merging to `main` triggers CI `auto_tag`, creating `pipelex-vscode-ext/v0.9.0` and `plxt-cli/v0.6.0`, which publish the extension (Marketplace/Open VSX) and the CLI (PyPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ships `pipelex` v0.9.0 and `plxt` v0.6.0 with MTHDS schema v0.31.0. Adds the `PipeSignature` blueprint and `PipeType` enum, requires an explicit `type` on every pipe blueprint, and speeds up CI packaging by skipping the Playwright browser download.

- **New Features**
  - `PipeSignature` blueprint: declare inputs/output without implementation to validate in-progress pipelines by mocking output.
  - `PipeType` enum, with optional `signature_for` hint on `PipeSignature`.

- **Migration**
  - Add `type` to every pipe table (e.g., `PipeLLM`, `PipeCompose`, `PipeSignature`). Omitting it now fails schema validation.

<sup>Written for commit d4acfc5e6fe2ddc249089bf1f1114f2a04269a7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/vscode-pipelex/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

