### PR TITLE
Feature/validate recursive

### DIFF
--- a/.claude/skills/bump-pipelex-version/SKILL.md
+++ b/.claude/skills/bump-pipelex-version/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: bump-pipelex-version
+description: >
+  Bump the minimum pipelex-agent CLI version required by the Pipelex VS Code
+  extension. Use when the user says "bump pipelex version", "raise the minimum
+  pipelex-agent version", "require pipelex X.Y.Z", "update the min CLI
+  version", "the extension needs a newer pipelex", or any variation of
+  changing the pipelex CLI version floor that the extension enforces at
+  runtime.
+---
+
+# Bump Minimum pipelex-agent Version
+
+The extension cannot enforce a Python package version at install time — `pipelex` lives in the user's environment (often a per-project `uv` env). Instead it probes `pipelex-agent --version` at runtime and gates features that need a newer CLI, surfacing an actionable upgrade message when the installed CLI is too old. The whole mechanism rests on one constant.
+
+**Single source of truth:** the exported minimum-version constant in `editors/vscode/src/pipelex/validation/agentCliVersion.ts` (currently `MIN_FORMAT_JSON_VERSION`). It is a `Semver` tuple `[major, minor, patch]`, not a string.
+
+## Workflow
+
+### 1. Determine the new version and the reason
+
+You need two things: the target version `X.Y.Z`, and the motivating feature — which CLI capability the extension now relies on. The reason matters as much as the number: it goes in the doc comment and the changelog, and it's what tells the next person why the floor is where it is. If the user gave a version without a reason, infer it from the current branch's work or ask.
+
+Show the current floor by reading the constant, then sanity-check that the target version actually exists: if the sibling `../pipelex` repo is present, confirm the version appears in its `CHANGELOG.md` or `pyproject.toml`; otherwise check PyPI (`curl -s https://pypi.org/pypi/pipelex/json | python3 -c "import json,sys; print(json.load(sys.stdin)['info']['version'])"`). Requiring a version that isn't released yet would break every user on update.
+
+### 2. Update the constant
+
+Edit `agentCliVersion.ts`:
+
+- Set the tuple to the new version.
+- Update the doc comment on the constant (and the module-level comment if it names the old floor) to record which feature requires the new minimum and which CLI version it landed in.
+- If the constant's name no longer matches the motivating feature (e.g. it's named after `--format json` but the bump is for something else), rename it and update all importers (`grep -rn "MIN_" editors/vscode/src --include="*.ts"`). Prefer generalizing to `MIN_AGENT_VERSION` as soon as more than one feature shares the floor — list each feature and the version it landed in inside the doc comment. A feature-named constant that lies about its reason is worse than no name at all.
+
+### 3. Check enforcement sites and stale references
+
+Grep the constant name across `editors/vscode/src` to find consumers. The method graph panel (`graph/methodGraphPanel.ts`) enforces the floor and renders the "too old, needs ≥ X" upgrade message. The version *numbers* in those messages interpolate the constant via `formatSemver` and need no edit — but the *reason* text does not: the message explains in prose why the floor exists (e.g. "the `--format json` option landed in that release"), and that sentence becomes false after the bump. Rewrite it to name the new motivating feature, and read the surrounding comments for the same problem.
+
+Distinguish two kinds of version mentions when sweeping (`grep -rn "<old X.Y.Z>" editors/vscode/src docs`):
+
+- **Statements about the current floor** — update these.
+- **Historical facts** (e.g. "`--format json` landed in 0.29.0", or released CHANGELOG entries) — leave them alone; they stay true forever.
+
+If the motivating feature affects the diagnostics validator (`validation/pipelexValidator.ts`), note that it does not currently version-gate at all — flag this to the user and ask whether to extend the same check there, rather than silently widening scope.
+
+### 4. Changelog
+
+Add an entry to `CHANGELOG.md` under `## [Unreleased]` (create that section right below the title if it doesn't exist), in a `### Changed` block:
+
+```
+- Minimum supported `pipelex-agent` raised to X.Y.Z — required for <feature>
+```
+
+### 5. Verify
+
+Run `cd editors/vscode && yarn test`. The existing tests use version strings only as mock probe output, not as assertions about the floor, so they normally pass unchanged — if one fails on a version literal, update the mock to a version at or above the new floor. For the full quality gate, run `make check` from the repo root.
+
+### 6. Report
+
+Show the version change `OLD → NEW`, the recorded reason, and the list of modified files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Pipelex IDE Extension and `plxt` CLI Changelog
 
+## [Unreleased]
+
+### Changed
+- On-save validation and the method graph pass `--allow-signatures` to `pipelex-agent validate bundle`, so work-in-progress bundles containing `PipeSignature` stubs validate and render instead of failing with `SignaturesNotAllowedError`
+- Minimum supported `pipelex-agent` raised to 0.31.0 — required for `--allow-signatures`
+
 ## [0.9.0] - 2026-05-31
 
 ### Changed

--- a/editors/vscode/src/pipelex/__tests__/methodGraphPanel.test.ts
+++ b/editors/vscode/src/pipelex/__tests__/methodGraphPanel.test.ts
@@ -281,6 +281,21 @@ describe('MethodGraphPanel', () => {
         panel.dispose();
     });
 
+    it('refresh() passes --library-dir with the bundle directory', async () => {
+        const processUtils = await import('../validation/processUtils');
+
+        const panel = new MethodGraphPanel(mockOutput(), makeExtensionUri());
+        const uri = makeUri('/project/methods/file.mthds');
+        panel.show(uri);
+        await new Promise(r => setTimeout(r, 50));
+
+        const args = vi.mocked(processUtils.spawnCli).mock.calls[0][1] as string[];
+        const idx = args.indexOf('--library-dir');
+        expect(idx).toBeGreaterThan(-1);
+        expect(args[idx + 1]).toBe('/project/methods');
+        panel.dispose();
+    });
+
     // --- Regression: staleness after spawnCli (previous Bug 1) ---
 
     it('refresh() discards spawnCli result when file switched during spawn', async () => {

--- a/editors/vscode/src/pipelex/__tests__/methodGraphPanel.test.ts
+++ b/editors/vscode/src/pipelex/__tests__/methodGraphPanel.test.ts
@@ -296,6 +296,19 @@ describe('MethodGraphPanel', () => {
         panel.dispose();
     });
 
+    it('refresh() passes --allow-signatures so stub pipes still render', async () => {
+        const processUtils = await import('../validation/processUtils');
+
+        const panel = new MethodGraphPanel(mockOutput(), makeExtensionUri());
+        const uri = makeUri('/project/file.mthds');
+        panel.show(uri);
+        await new Promise(r => setTimeout(r, 50));
+
+        const args = vi.mocked(processUtils.spawnCli).mock.calls[0][1] as string[];
+        expect(args).toContain('--allow-signatures');
+        panel.dispose();
+    });
+
     // --- Regression: staleness after spawnCli (previous Bug 1) ---
 
     it('refresh() discards spawnCli result when file switched during spawn', async () => {

--- a/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
+++ b/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { resolveCli } from '../validation/cliResolver';
 import { spawnCli, cancelAllInflight } from '../validation/processUtils';
-import { getAgentCliVersion, compareSemver, formatSemver, MIN_FORMAT_JSON_VERSION } from '../validation/agentCliVersion';
+import { getAgentCliVersion, compareSemver, formatSemver, MIN_AGENT_VERSION } from '../validation/agentCliVersion';
 import { extractJson } from '../validation/pipelexValidator';
 import type { ValidationFailure } from '../validation/types';
 import { findTableHeader } from '../validation/sourceLocator';
@@ -262,11 +262,12 @@ export class MethodGraphPanel implements vscode.Disposable {
         const showControllers = pipelexConfig.get<boolean>('graph.showControllers', true);
         const foldMode = pipelexConfig.get<string>('graph.foldMode', 'folded');
         const filePath = uri.fsPath;
-        // pipelex-agent >= 0.29.0 defaults to markdown output and needs `--format json` to emit
-        // structured JSON. Always pass it; if the CLI predates 0.29.0 the invocation will fail
-        // and the catch block surfaces a targeted upgrade message. `--library-dir` landed in
-        // 0.18.2, so the same 0.29.0 floor covers it — no separate version check needed.
-        const args = [...resolved.args, 'validate', 'bundle', filePath, '--library-dir', path.dirname(filePath), '--view', '--direction', direction, '--format', 'json'];
+        // `--allow-signatures` (0.31.0) lets the graph render bundles that still contain
+        // PipeSignature stubs. Always pass it; if the CLI predates the floor the invocation
+        // will fail and the catch block surfaces a targeted upgrade message. `--format json`
+        // (0.29.0) and `--library-dir` (0.18.2) landed earlier, so the same floor covers
+        // them — no separate version checks needed.
+        const args = [...resolved.args, 'validate', 'bundle', filePath, '--library-dir', path.dirname(filePath), '--allow-signatures', '--view', '--direction', direction, '--format', 'json'];
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
         const cwd = workspaceFolder?.uri.fsPath;
 
@@ -302,20 +303,20 @@ export class MethodGraphPanel implements vscode.Disposable {
             if (this.currentUri?.toString() !== uri.toString()) return;
 
             // Before falling into the generic error paths, check whether the failure
-            // is just an outdated `pipelex-agent` that predates `--format json` (0.29.0).
+            // is just an outdated `pipelex-agent` that predates `--allow-signatures` (0.31.0).
             const installedVersion = await getAgentCliVersion(resolved.command, resolved.args, cwd);
-            if (installedVersion && compareSemver(installedVersion, MIN_FORMAT_JSON_VERSION) < 0) {
+            if (installedVersion && compareSemver(installedVersion, MIN_AGENT_VERSION) < 0) {
                 if (controller.signal.aborted) return;
                 if (this.currentUri?.toString() !== uri.toString()) return;
                 this.output.appendLine(
                     `pipelex-agent ${formatSemver(installedVersion)} is too old for the graph panel ` +
-                    `(needs ≥ ${formatSemver(MIN_FORMAT_JSON_VERSION)}).`
+                    `(needs ≥ ${formatSemver(MIN_AGENT_VERSION)}).`
                 );
                 this.setHtml(messageHtml(
                     'Update Pipelex',
                     `Your installed <code>pipelex-agent</code> is <strong>${escapeHtml(formatSemver(installedVersion))}</strong>, ` +
-                    `but the method graph requires <strong>≥ ${escapeHtml(formatSemver(MIN_FORMAT_JSON_VERSION))}</strong> ` +
-                    `(the <code>--format json</code> option landed in that release).` +
+                    `but the method graph requires <strong>≥ ${escapeHtml(formatSemver(MIN_AGENT_VERSION))}</strong> ` +
+                    `(the <code>--allow-signatures</code> option landed in that release).` +
                     `</p><p>` +
                     `Upgrade Pipelex and try again:<br>` +
                     `<code>mthds runner setup pipelex</code> (mthds-managed install)<br>` +

--- a/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
+++ b/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
@@ -264,7 +264,8 @@ export class MethodGraphPanel implements vscode.Disposable {
         const filePath = uri.fsPath;
         // pipelex-agent >= 0.29.0 defaults to markdown output and needs `--format json` to emit
         // structured JSON. Always pass it; if the CLI predates 0.29.0 the invocation will fail
-        // and the catch block surfaces a targeted upgrade message.
+        // and the catch block surfaces a targeted upgrade message. `--library-dir` landed in
+        // 0.18.2, so the same 0.29.0 floor covers it — no separate version check needed.
         const args = [...resolved.args, 'validate', 'bundle', filePath, '--library-dir', path.dirname(filePath), '--view', '--direction', direction, '--format', 'json'];
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
         const cwd = workspaceFolder?.uri.fsPath;

--- a/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
+++ b/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as crypto from 'crypto';
 import * as fs from 'fs';
+import * as path from 'path';
 import { resolveCli } from '../validation/cliResolver';
 import { spawnCli, cancelAllInflight } from '../validation/processUtils';
 import { getAgentCliVersion, compareSemver, formatSemver, MIN_FORMAT_JSON_VERSION } from '../validation/agentCliVersion';
@@ -264,7 +265,7 @@ export class MethodGraphPanel implements vscode.Disposable {
         // pipelex-agent >= 0.29.0 defaults to markdown output and needs `--format json` to emit
         // structured JSON. Always pass it; if the CLI predates 0.29.0 the invocation will fail
         // and the catch block surfaces a targeted upgrade message.
-        const args = [...resolved.args, 'validate', 'bundle', filePath, '--view', '--direction', direction, '--format', 'json'];
+        const args = [...resolved.args, 'validate', 'bundle', filePath, '--library-dir', path.dirname(filePath), '--view', '--direction', direction, '--format', 'json'];
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
         const cwd = workspaceFolder?.uri.fsPath;
 

--- a/editors/vscode/src/pipelex/validation/agentCliVersion.ts
+++ b/editors/vscode/src/pipelex/validation/agentCliVersion.ts
@@ -6,14 +6,19 @@ import { execFile } from 'child_process';
  * for the lifetime of the extension host.
  *
  * Used to give actionable error messages when an installed `pipelex-agent`
- * predates a feature the extension relies on (e.g. `--format json`, which
- * landed in 0.29.0).
+ * predates a feature the extension relies on (e.g. `--allow-signatures`,
+ * which landed in 0.31.0).
  */
 
 export type Semver = readonly [number, number, number];
 
-/** First `pipelex-agent` version that accepts `validate bundle --format json`. */
-export const MIN_FORMAT_JSON_VERSION: Semver = [0, 29, 0];
+/**
+ * Minimum `pipelex-agent` version the extension relies on. Features that set
+ * this floor:
+ * - `validate bundle --format json` (landed in 0.29.0)
+ * - `validate bundle --allow-signatures` (landed in 0.31.0)
+ */
+export const MIN_AGENT_VERSION: Semver = [0, 31, 0];
 
 const cache = new Map<string, Promise<Semver | null>>();
 

--- a/editors/vscode/src/pipelex/validation/pipelexValidator.ts
+++ b/editors/vscode/src/pipelex/validation/pipelexValidator.ts
@@ -77,6 +77,7 @@ export class PipelexValidator implements vscode.Disposable {
 
         const timeout = config.get<number>('validation.timeout', 30000);
         const filePath = document.uri.fsPath;
+        // `--library-dir` is supported by pipelex-agent since 0.18.2 — safe to pass unconditionally.
         const args = [...resolved.args, 'validate', 'bundle', filePath, '--library-dir', path.dirname(filePath)];
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
         const cwd = workspaceFolder?.uri.fsPath;

--- a/editors/vscode/src/pipelex/validation/pipelexValidator.ts
+++ b/editors/vscode/src/pipelex/validation/pipelexValidator.ts
@@ -77,8 +77,10 @@ export class PipelexValidator implements vscode.Disposable {
 
         const timeout = config.get<number>('validation.timeout', 30000);
         const filePath = document.uri.fsPath;
-        // `--library-dir` is supported by pipelex-agent since 0.18.2 — safe to pass unconditionally.
-        const args = [...resolved.args, 'validate', 'bundle', filePath, '--library-dir', path.dirname(filePath)];
+        // `--allow-signatures` (pipelex-agent 0.31.0, the extension's version floor) keeps
+        // on-save validation lenient about PipeSignature stubs in work-in-progress bundles.
+        // `--library-dir` (0.18.2) is covered by the same floor.
+        const args = [...resolved.args, 'validate', 'bundle', filePath, '--library-dir', path.dirname(filePath), '--allow-signatures'];
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
         const cwd = workspaceFolder?.uri.fsPath;
 

--- a/editors/vscode/src/pipelex/validation/pipelexValidator.ts
+++ b/editors/vscode/src/pipelex/validation/pipelexValidator.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { resolveCli } from './cliResolver';
 import { locateError } from './sourceLocator';
 import { spawnCli, cancelInflightByKey } from './processUtils';
@@ -76,7 +77,7 @@ export class PipelexValidator implements vscode.Disposable {
 
         const timeout = config.get<number>('validation.timeout', 30000);
         const filePath = document.uri.fsPath;
-        const args = [...resolved.args, 'validate', 'bundle', filePath];
+        const args = [...resolved.args, 'validate', 'bundle', filePath, '--library-dir', path.dirname(filePath)];
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
         const cwd = workspaceFolder?.uri.fsPath;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enables in-progress bundles to validate and render by passing `--allow-signatures` and `--library-dir` to `pipelex-agent validate bundle`. Raises the minimum supported `pipelex-agent` to 0.31.0 and updates the upgrade message.

- **New Features**
  - On-save validation and the method graph pass `--allow-signatures`, so bundles with `PipeSignature` stubs validate and render.
  - Both commands pass `--library-dir <bundle dir>` so sibling bundles resolve as library imports.

- **Dependencies**
  - Minimum supported `pipelex-agent` raised to 0.31.0; version constant generalized to `MIN_AGENT_VERSION` and the graph panel’s upgrade message updated.
  - Tests added to assert the new flags; changelog updated.

<sup>Written for commit 3b674659a272d2ff6948a98ea61957ced1ecf35e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/vscode-pipelex/pull/49?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

