### PR TITLE
[codex] Prefer concrete MTHDS pipe navigation targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+@CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+ - **Cross-file pipe-node graph navigation:** Clicking a pipe node in the method graph now opens that pipe's declaration even when it lives in a sibling `.mthds` file. Navigation uses the runtime registry's `source` hint when valid, falls back to declaration scanning when stale/missing, and preserves domain identity when multiple domains reuse the same pipe code.
  - **Python library bindings (`pipelex-tools-py`)**: New, independently versioned PyPI package exposing MTHDS linting and formatting as in-process functions (`format_mthds`, `lint_mthds`). Built with PyO3 over the existing `taplo`/`taplo-common` engine, it returns structured diagnostics (`{kind, severity, message, location, range}`) instead of raising exceptions, validates against the embedded official MTHDS schema fully offline, and ships PEP 561 type stubs (`pipelex_tools.pyi`, `py.typed`) for static typing and editor autocomplete.
  - **Parity test suite** (`crates/pipelex-cli/tests/parity.rs`): Asserts the Python library's output is byte-for-byte identical to the `plxt` CLI, preventing drift between the two interfaces.
  - **Dedicated CI workflows**: `.github/workflows/check.yml` runs the core PR quality gate (`make check`: formatting, clippy, tests, WASM compilation), and `.github/workflows/test-all.yml` runs `make test-all`, including the Python wheel build and import smoke tests.

--- a/crates/pipelex-cli/tests/quiet_flag.rs
+++ b/crates/pipelex-cli/tests/quiet_flag.rs
@@ -53,9 +53,9 @@ fn no_quiet_invalid_file_has_tracing() {
 
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    // Without --quiet, tracing INFO lines should appear
+    // Without --quiet, the redundant tracing trailer should appear.
     assert!(
-        stderr.contains("INFO") || stderr.contains("found"),
+        stderr.contains("operation failed"),
         "expected tracing output without --quiet, got: {stderr}"
     );
 }

--- a/crates/taplo-lsp/src/handlers/goto_definition.rs
+++ b/crates/taplo-lsp/src/handlers/goto_definition.rs
@@ -172,7 +172,7 @@ async fn resolve_pipe_definition_across_bundle<E: Environment>(
 
         if let Some((uri, doc)) = open_by_path.remove(&path) {
             if let Some(definition) =
-                pipe_definition_from_document(uri, doc.dom, doc.mapper, pipe_name)
+                pipe_definition_from_document(uri, &doc.dom, doc.mapper, pipe_name)
             {
                 definitions.push(definition);
             }
@@ -191,7 +191,7 @@ async fn resolve_pipe_definition_across_bundle<E: Environment>(
         let parse = parser::parse(&source);
         let dom = parse.into_dom();
         let mapper = Mapper::new_utf16(&source, false);
-        if let Some(definition) = pipe_definition_from_document(uri, dom, mapper, pipe_name) {
+        if let Some(definition) = pipe_definition_from_document(uri, &dom, mapper, pipe_name) {
             definitions.push(definition);
         }
     }
@@ -221,7 +221,7 @@ fn percent_encode_file_path(path: &str) -> String {
     for byte in path.bytes() {
         match byte {
             b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' | b':' => {
-                encoded.push(byte as char)
+                encoded.push(byte as char);
             }
             _ => {
                 write!(&mut encoded, "%{byte:02X}").expect("writing to string cannot fail");
@@ -233,12 +233,12 @@ fn percent_encode_file_path(path: &str) -> String {
 
 fn pipe_definition_from_document(
     uri: Url,
-    dom: Node,
+    dom: &Node,
     mapper: Mapper,
     pipe_name: &str,
 ) -> Option<PipeDefinition> {
-    let domain = document_domain(&dom);
-    let node = pipe_node(&dom, pipe_name)?;
+    let domain = document_domain(dom);
+    let node = pipe_node(dom, pipe_name)?;
     let is_signature = pipe_definition_is_signature(&node);
     Some(PipeDefinition {
         uri,
@@ -316,7 +316,7 @@ mod tests {
         let parse = parser::parse(source);
         let dom = parse.into_dom();
         let mapper = Mapper::new_utf16(source, false);
-        pipe_definition_from_document(Url::parse(uri).unwrap(), dom, mapper, pipe_name).unwrap()
+        pipe_definition_from_document(Url::parse(uri).unwrap(), &dom, mapper, pipe_name).unwrap()
     }
 
     #[test]

--- a/crates/taplo-lsp/src/handlers/goto_definition.rs
+++ b/crates/taplo-lsp/src/handlers/goto_definition.rs
@@ -1,11 +1,24 @@
-use crate::{handlers::mthds_resolution::resolve_reference, query::Query, world::World};
+use crate::{
+    handlers::mthds_resolution::{classify_reference, resolve_reference, ReferenceKind},
+    query::Query,
+    world::{DocumentState, World},
+};
 use lsp_async_stub::{
     rpc::Error,
-    util::{LspExt, Position},
+    util::{LspExt, Mapper, Position},
     Context, Params,
 };
-use lsp_types::{GotoDefinitionParams, GotoDefinitionResponse, Location};
+use lsp_types::{GotoDefinitionParams, GotoDefinitionResponse, Location, Url};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Write,
+    path::{Path, PathBuf},
+};
 use taplo::dom::node::DomNode;
+use taplo::{
+    dom::{KeyOrIndex, Keys, Node},
+    parser,
+};
 use taplo_common::environment::Environment;
 
 #[tracing::instrument(skip_all)]
@@ -24,14 +37,23 @@ pub(crate) async fn goto_definition<E: Environment>(
 
     tracing::debug!(%document_uri, "goto_definition: handling MTHDS file");
 
-    let workspaces = context.workspaces.read().await;
-    let ws = workspaces.by_document(&document_uri);
-    let doc = match ws.document(&document_uri) {
-        Ok(d) => d,
-        Err(error) => {
-            tracing::debug!(%error, "goto_definition: failed to get document");
-            return Ok(None);
-        }
+    let (doc, open_mthds_documents) = {
+        let workspaces = context.workspaces.read().await;
+        let ws = workspaces.by_document(&document_uri);
+        let doc = match ws.document(&document_uri) {
+            Ok(d) => d.clone(),
+            Err(error) => {
+                tracing::debug!(%error, "goto_definition: failed to get document");
+                return Ok(None);
+            }
+        };
+        let open_mthds_documents = ws
+            .documents
+            .iter()
+            .filter(|(uri, _)| uri.as_str().ends_with(".mthds"))
+            .map(|(uri, doc)| (uri.clone(), doc.clone()))
+            .collect::<Vec<_>>();
+        (doc, open_mthds_documents)
     };
 
     let position = p.text_document_position_params.position;
@@ -41,6 +63,32 @@ pub(crate) async fn goto_definition<E: Environment>(
     };
 
     let query = Query::at(&doc.dom, offset);
+
+    let Some(classified) = classify_reference(&query) else {
+        tracing::debug!("goto_definition: no reference classified at cursor");
+        return Ok(None);
+    };
+
+    if matches!(&classified.kind, ReferenceKind::Pipe) {
+        let current_domain = document_domain(&doc.dom);
+        if let Some(location) = resolve_pipe_definition_across_bundle(
+            &context.env,
+            &document_uri,
+            &open_mthds_documents,
+            &classified.ref_name,
+            current_domain.as_deref(),
+        )
+        .await
+        {
+            tracing::debug!(
+                ref_name = %classified.ref_name,
+                uri = %location.uri,
+                ?location.range,
+                "goto_definition: resolved pipe across MTHDS bundle"
+            );
+            return Ok(Some(GotoDefinitionResponse::Scalar(location)));
+        }
+    }
 
     let Some(resolved) = resolve_reference(&doc.dom, &query) else {
         tracing::debug!("goto_definition: no reference resolved at cursor");
@@ -74,4 +122,273 @@ pub(crate) async fn goto_definition<E: Environment>(
         uri: document_uri,
         range: range.into_lsp(),
     })))
+}
+
+struct PipeDefinition {
+    uri: Url,
+    node: Node,
+    mapper: Mapper,
+    domain: Option<String>,
+    is_signature: bool,
+}
+
+async fn resolve_pipe_definition_across_bundle<E: Environment>(
+    env: &E,
+    document_uri: &Url,
+    open_mthds_documents: &[(Url, DocumentState)],
+    pipe_name: &str,
+    preferred_domain: Option<&str>,
+) -> Option<Location> {
+    let current_path = env.to_file_path_normalized(document_uri)?;
+    let current_dir = current_path.parent()?.to_path_buf();
+
+    let mut open_by_path = HashMap::<PathBuf, (Url, DocumentState)>::new();
+    for (uri, doc) in open_mthds_documents {
+        let Some(path) = env.to_file_path_normalized(uri) else {
+            continue;
+        };
+        if path.parent() == Some(current_dir.as_path()) {
+            open_by_path.insert(path, (uri.clone(), doc.clone()));
+        }
+    }
+
+    let mut paths = bundle_mthds_paths(env, &current_dir);
+    if !paths.iter().any(|path| path == &current_path) {
+        paths.push(current_path.clone());
+    }
+    paths.sort();
+    paths.sort_by(|a, b| match (a == &current_path, b == &current_path) {
+        (true, false) => std::cmp::Ordering::Less,
+        (false, true) => std::cmp::Ordering::Greater,
+        _ => a.cmp(b),
+    });
+
+    let mut seen = HashSet::<PathBuf>::new();
+    let mut definitions = Vec::new();
+    for path in paths {
+        if !seen.insert(path.clone()) {
+            continue;
+        }
+
+        if let Some((uri, doc)) = open_by_path.remove(&path) {
+            if let Some(definition) =
+                pipe_definition_from_document(uri, doc.dom, doc.mapper, pipe_name)
+            {
+                definitions.push(definition);
+            }
+            continue;
+        }
+
+        let Some(uri) = file_url_from_path(&path) else {
+            continue;
+        };
+        let Ok(bytes) = env.read_file(&path).await else {
+            continue;
+        };
+        let Ok(source) = String::from_utf8(bytes) else {
+            continue;
+        };
+        let parse = parser::parse(&source);
+        let dom = parse.into_dom();
+        let mapper = Mapper::new_utf16(&source, false);
+        if let Some(definition) = pipe_definition_from_document(uri, dom, mapper, pipe_name) {
+            definitions.push(definition);
+        }
+    }
+
+    select_preferred_pipe_definition(definitions, preferred_domain)?.into_location()
+}
+
+fn bundle_mthds_paths<E: Environment>(env: &E, current_dir: &Path) -> Vec<PathBuf> {
+    let mut pattern = current_dir.to_path_buf();
+    pattern.push("*.mthds");
+    env.glob_files_normalized(&pattern.to_string_lossy())
+        .unwrap_or_default()
+}
+
+fn file_url_from_path(path: &Path) -> Option<Url> {
+    let path = path.to_string_lossy().replace('\\', "/");
+    let mut url = String::from("file://");
+    if !path.starts_with('/') {
+        url.push('/');
+    }
+    url.push_str(&percent_encode_file_path(&path));
+    Url::parse(&url).ok()
+}
+
+fn percent_encode_file_path(path: &str) -> String {
+    let mut encoded = String::with_capacity(path.len());
+    for byte in path.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' | b':' => {
+                encoded.push(byte as char)
+            }
+            _ => {
+                write!(&mut encoded, "%{byte:02X}").expect("writing to string cannot fail");
+            }
+        }
+    }
+    encoded
+}
+
+fn pipe_definition_from_document(
+    uri: Url,
+    dom: Node,
+    mapper: Mapper,
+    pipe_name: &str,
+) -> Option<PipeDefinition> {
+    let domain = document_domain(&dom);
+    let node = pipe_node(&dom, pipe_name)?;
+    let is_signature = pipe_definition_is_signature(&node);
+    Some(PipeDefinition {
+        uri,
+        node,
+        mapper,
+        domain,
+        is_signature,
+    })
+}
+
+fn select_preferred_pipe_definition(
+    definitions: Vec<PipeDefinition>,
+    preferred_domain: Option<&str>,
+) -> Option<PipeDefinition> {
+    let mut definitions = if let Some(preferred_domain) = preferred_domain {
+        let (same_domain, other_domain): (Vec<_>, Vec<_>) = definitions
+            .into_iter()
+            .partition(|definition| definition.domain.as_deref() == Some(preferred_domain));
+        if same_domain.is_empty() {
+            other_domain
+        } else {
+            same_domain
+        }
+    } else {
+        definitions
+    };
+
+    definitions.sort_by_key(|definition| definition.is_signature);
+
+    let mut definitions = definitions.into_iter();
+    definitions.next()
+}
+
+fn pipe_node(dom: &Node, pipe_name: &str) -> Option<Node> {
+    let target_keys = Keys::new(
+        [
+            KeyOrIndex::Key(taplo::dom::node::Key::new("pipe")),
+            KeyOrIndex::Key(taplo::dom::node::Key::new(pipe_name)),
+        ]
+        .into_iter(),
+    );
+    dom.path(&target_keys)
+}
+
+fn pipe_definition_is_signature(node: &Node) -> bool {
+    node.get("type")
+        .as_str()
+        .map(|s| s.value() == "PipeSignature")
+        .unwrap_or(false)
+}
+
+fn document_domain(dom: &Node) -> Option<String> {
+    dom.get("domain")
+        .as_str()
+        .map(|s| s.value().to_string())
+        .filter(|domain| !domain.is_empty())
+}
+
+impl PipeDefinition {
+    fn into_location(self) -> Option<Location> {
+        let syntax = self.node.syntax()?;
+        let range = self.mapper.range(syntax.text_range())?;
+        Some(Location {
+            uri: self.uri,
+            range: range.into_lsp(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pipe_definition(uri: &str, source: &str, pipe_name: &str) -> PipeDefinition {
+        let parse = parser::parse(source);
+        let dom = parse.into_dom();
+        let mapper = Mapper::new_utf16(source, false);
+        pipe_definition_from_document(Url::parse(uri).unwrap(), dom, mapper, pipe_name).unwrap()
+    }
+
+    #[test]
+    fn prefers_concrete_definition_over_signature() {
+        let signature = pipe_definition(
+            "file:///project/bundle.mthds",
+            "domain = \"rec\"\n[pipe.screen]\ntype = \"PipeSignature\"\n",
+            "screen",
+        );
+        let concrete = pipe_definition(
+            "file:///project/screen.mthds",
+            "domain = \"rec\"\n[pipe.screen]\ntype = \"PipeSequence\"\n",
+            "screen",
+        );
+
+        let selected =
+            select_preferred_pipe_definition(vec![signature, concrete], Some("rec")).unwrap();
+
+        assert_eq!(selected.uri.as_str(), "file:///project/screen.mthds");
+    }
+
+    #[test]
+    fn falls_back_to_first_signature_when_no_concrete_exists() {
+        let signature = pipe_definition(
+            "file:///project/bundle.mthds",
+            "domain = \"rec\"\n[pipe.screen]\ntype = \"PipeSignature\"\n",
+            "screen",
+        );
+
+        let selected = select_preferred_pipe_definition(vec![signature], Some("rec")).unwrap();
+
+        assert_eq!(selected.uri.as_str(), "file:///project/bundle.mthds");
+    }
+
+    #[test]
+    fn prefers_concrete_definition_in_matching_domain() {
+        let alpha_concrete = pipe_definition(
+            "file:///project/alpha.mthds",
+            "domain = \"alpha\"\n[pipe.screen]\ntype = \"PipeSequence\"\n",
+            "screen",
+        );
+        let beta_signature = pipe_definition(
+            "file:///project/beta_sig.mthds",
+            "domain = \"beta\"\n[pipe.screen]\ntype = \"PipeSignature\"\n",
+            "screen",
+        );
+        let beta_concrete = pipe_definition(
+            "file:///project/beta_impl.mthds",
+            "domain = \"beta\"\n[pipe.screen]\ntype = \"PipeLLM\"\n",
+            "screen",
+        );
+
+        let selected = select_preferred_pipe_definition(
+            vec![alpha_concrete, beta_signature, beta_concrete],
+            Some("beta"),
+        )
+        .unwrap();
+
+        assert_eq!(selected.uri.as_str(), "file:///project/beta_impl.mthds");
+    }
+
+    #[test]
+    fn builds_file_url_from_unix_path_with_spaces() {
+        let url = file_url_from_path(Path::new("/project/my methods/screen.mthds")).unwrap();
+
+        assert_eq!(url.as_str(), "file:///project/my%20methods/screen.mthds");
+    }
+
+    #[test]
+    fn builds_file_url_from_windows_path() {
+        let url = file_url_from_path(Path::new("C:\\project\\screen.mthds")).unwrap();
+
+        assert_eq!(url.as_str(), "file:///C:/project/screen.mthds");
+    }
 }

--- a/docs/features/graph-pipe-navigation.md
+++ b/docs/features/graph-pipe-navigation.md
@@ -1,0 +1,55 @@
+# Cross-file pipe-node navigation in the method graph
+
+Clicking a pipe node in the method graph panel opens that pipe's `[pipe.<code>]` declaration in the editor — **across every `.mthds` file in the bundle directory**, not just the file the panel was opened from. When a method is split across several files (e.g. a signature in one file, the concrete implementation in a sibling), clicking the node lands on the file that actually declares it.
+
+## Scope
+
+- **Pipes only, strictly click-to-code.** Concept-to-code navigation and `--pipe` graph-targeting are tracked as follow-ups, not implemented here.
+- **`.mthds` sources only.** A run-graph GraphSpec JSON (`graphspec-json` source kind) has no editable bundle in the workspace, so node navigation is disabled for it.
+
+## How resolution works — source-first, scan-as-fallback
+
+When the webview reports a clicked pipe node, the panel resolves the declaring file in two feature-detected tiers, then finds the exact line:
+
+1. **Source (exact).** The retained GraphSpec's `pipe_registry[<domain>.<code>].source` names the declaring file. The collision reconciler in the runtime makes `source` follow the **winning** declaration, so for a signature/concrete pair it points at the concrete implementation — the file you actually want. Keyed on `domain.code`, so same-named pipes in different domains resolve correctly.
+2. **Scan (fallback).** When `source` is absent — an older CLI that doesn't emit it, or a synthesized pipe with no declaring file — the extension gathers the sibling `.mthds` files and finds the one declaring `[pipe.<code>]`. On a header collision it prefers the file whose top-level `domain = "<domainCode>"` matches the clicked node.
+3. **Primary fallback.** If neither tier resolves a sibling, it opens the panel's own file (today's single-file behavior). If even that file doesn't declare the header, the attempt is a silent no-op logged to the Pipelex output channel — exactly as before.
+
+In every tier the declaring **file** is resolved first; the exact **line** then comes from scanning that file's opened document for the `[pipe.<code>]` header. The runtime deliberately does not own editor-range semantics — line-finding stays a presentation concern in the extension.
+
+## Feature detection across CLI versions
+
+The `source` field is **additive** and feature-detected — there is **no minimum CLI version bump** for this feature. A CLI new enough to emit `source` gets exact tier-1 resolution; an older CLI that omits it degrades cleanly to the tier-2 scan, which behaves like the original single-file navigation when the pipe lives in the panel's own file. Nothing breaks on either side of the version line.
+
+## Single owner resolver — shared with cross-file diagnostics
+
+The matching logic lives in one module, `editors/vscode/src/pipelex/validation/bundleResolution.ts`, and is shared by **both** the pipe-node navigation path and the validation-error placement path (`crossFileDiagnostics.ts`). They can never drift on how a `source` path is matched or how a declaration header is located. The two paths differ only in composition order: an error may carry both a `pipe_code` and a `concept_code` (resolved `source` → pipe → concept), while navigation resolves a single kind. Source-path matching tolerates absolute and relative values alike and normalizes separators, so it works whether the CLI emits absolute host paths or the API emits per-content names.
+
+## Unsaved-sibling caveat
+
+Resolution reads sibling files **from disk** (the same flat directory gather the cross-file diagnostics use — a non-recursive `*.mthds` glob, matching the CLI's `--library-dir`). The file that is finally opened still shows its live editor buffer, so the primary file's unsaved edits are honored when finding the line; an unsaved **sibling** is matched against its on-disk text. Reading unsaved sibling buffers for resolution is a deferred refinement.
+
+## Node identity (and a known v1 edge)
+
+The webview message carries only the bare `pipeCode`. The panel recovers the clicked node's `domain_code` by looking it up in the retained GraphSpec (stored whenever the graph is sent to the webview, cleared on dispose), then forms the `domain.code` registry key. If the same `pipe_code` appears under two domains as two nodes in one graph, the first node match wins — acceptable for v1, because the scan fallback still finds a correct declaration. The bulletproof upgrade is to wire mthds-ui's `onNodeSelect(nodeId, nodeData)` (already available; `nodeData` carries the full node, including `domain_code`) and post a unique `nodeId` instead — recorded as a future improvement so the webview message contract stays unchanged here.
+
+## Files
+
+| File | Role |
+|------|------|
+| `editors/vscode/src/pipelex/validation/bundleResolution.ts` | Shared declaring-file resolver (`resolveDeclaringFile`, `matchSourceFile`, `findDeclaringFileByScan`) |
+| `editors/vscode/src/pipelex/validation/crossFileDiagnostics.ts` | Validation-error owner resolution, delegating to the shared primitives |
+| `editors/vscode/src/pipelex/graph/methodGraphPanel.ts` | Retains the GraphSpec, resolves a clicked node to its declaring file, opens-and-reveals beside the panel (`navigateToPipe`, `lookupPipeNode`, `revealRangeBeside`) |
+| `editors/vscode/src/pipelex/graph/webview/adapter.ts` | Webview entry; posts `{ type: 'navigateToPipe', pipeCode }` on a node click |
+
+## Cross-repo dependency
+
+The `source` enrichment is produced by the runtime in `../pipelex` — `GraphSpec.pipe_registry[ref].source` (and the symmetric `concept_registry[ref].source`), powered by `LibraryCrate.source_map`. See `../pipelex/pipelex/graph/graphspec.py` for the data model the extension consumes.
+
+## Verification
+
+```bash
+cd editors/vscode && yarn vitest run src/pipelex/__tests__/bundleResolution.test.ts   # resolver unit tests
+cd editors/vscode && yarn vitest run src/pipelex/__tests__/methodGraphPanel.test.ts   # navigation integration tests
+make test-ext                                                                          # extension tsc + vitest
+```

--- a/docs/features/validation-backends.md
+++ b/docs/features/validation-backends.md
@@ -57,7 +57,7 @@ When a `.mthds` bundle fails validation it produces **no** method graph, so the 
 
 - A header counts the errors and reminds you to **fix and save to regenerate the graph**.
 - Each row shows the error message, its `pipe.<code>` / `concept.<code>` context when the error names one, and — for an error that lives in a **sibling** file — that file's name, so a cross-file failure is attributed to the right place (single-file bundles, and errors on the file you saved, stay clean with no file label).
-- Each row is **clickable**: it opens the owning file (which may be a sibling) at the error's line, in the editor column beside the panel — the same navigation the graph's pipe nodes use.
+- Each row is **clickable**: it opens the owning file (which may be a sibling) at the error's line, in the editor column beside the panel — the same owner resolver and open-and-reveal the graph's pipe nodes use for [cross-file pipe navigation](./graph-pipe-navigation.md).
 - A **Retry** button re-runs the analysis, matching the panel's other error states.
 
 Fix the reported errors and save: the panel regenerates the graph. (This applies to `.mthds` sources only — a run-graph GraphSpec JSON never yields validation errors.)

--- a/editors/vscode/src/pipelex/__tests__/bundleResolution.test.ts
+++ b/editors/vscode/src/pipelex/__tests__/bundleResolution.test.ts
@@ -42,6 +42,14 @@ describe('resolveDeclaringFile — source-first tier', () => {
         expect(owner?.uri.toString()).toBe(CONCRETE.uri.toString());
     });
 
+    it('supersedes a signature `source` with a same-domain concrete declaration', () => {
+        const owner = resolveDeclaringFile({
+            kind: 'pipe', code: 'screen', domainCode: 'rec',
+            source: `${DIR}/bundle.mthds`, files, getLines,
+        });
+        expect(owner?.uri.toString()).toBe(CONCRETE.uri.toString());
+    });
+
     it('resolves a bare-basename `source` by basename', () => {
         const owner = resolveDeclaringFile({
             kind: 'pipe', code: 'screen', source: 'screen.mthds', files, getLines,
@@ -76,6 +84,32 @@ describe('resolveDeclaringFile — source-first tier', () => {
 });
 
 describe('resolveDeclaringFile — scan fallback tier (no source)', () => {
+    it('prefers a concrete pipe over a same-code signature when source is absent', () => {
+        const owner = resolveDeclaringFile({
+            kind: 'pipe', code: 'screen', files: [SIGNATURE, CONCRETE, CONCEPTS], getLines,
+        });
+        expect(owner?.uri.toString()).toBe(CONCRETE.uri.toString());
+    });
+
+    it('prefers the concrete pipe within the clicked domain when duplicate names span domains', () => {
+        const alphaConcrete = makeFile(`${DIR}/alpha.mthds`, 'alpha.mthds',
+            'domain = "alpha"\n[pipe.screen]\ntype = "PipeSequence"\n');
+        const betaSignature = makeFile(`${DIR}/beta-signature.mthds`, 'beta-signature.mthds',
+            'domain = "beta"\n[pipe.screen]\ntype = "PipeSignature"\n');
+        const betaConcrete = makeFile(`${DIR}/beta-concrete.mthds`, 'beta-concrete.mthds',
+            'domain = "beta"\n[pipe.screen]\ntype = "PipeLLM"\n');
+
+        const owner = resolveDeclaringFile({
+            kind: 'pipe',
+            code: 'screen',
+            domainCode: 'beta',
+            files: [alphaConcrete, betaSignature, betaConcrete],
+            getLines,
+        });
+
+        expect(owner?.uri.toString()).toBe(betaConcrete.uri.toString());
+    });
+
     it('finds the file declaring `[pipe.<code>]`', () => {
         const owner = resolveDeclaringFile({
             kind: 'pipe', code: 'build', files: [SIGNATURE, CONCRETE, CONCEPTS], getLines,

--- a/editors/vscode/src/pipelex/__tests__/bundleResolution.test.ts
+++ b/editors/vscode/src/pipelex/__tests__/bundleResolution.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// ---------- vscode mock ----------
+// bundleResolution.ts pulls in sourceLocator, which does `import * as vscode`.
+// Only `Uri.file` is touched at import time; the resolver logic itself is vscode-free.
+vi.mock('vscode', () => ({
+    Uri: {
+        file: (p: string) => ({ fsPath: p, scheme: 'file', toString: () => `file://${p}` }),
+    },
+}));
+
+import { resolveDeclaringFile, matchSourceFile, findDeclaringFileByScan } from '../validation/bundleResolution';
+import type { BundleFile } from '../validation/backend';
+
+const DIR = '/project/methods';
+
+function makeFile(fsPath: string, name: string, content: string): BundleFile {
+    return { uri: { fsPath, scheme: 'file', toString: () => `file://${fsPath}` } as any, name, content };
+}
+
+const getLines = (f: BundleFile): string[] => f.content.split(/\r\n|\r|\n/);
+
+// A signature/concrete split: the primary holds the signature, a sibling the concrete impl.
+const SIGNATURE = makeFile(`${DIR}/bundle.mthds`, 'bundle.mthds',
+    'domain = "rec"\n[pipe.screen]\ntype = "PipeSignature"\n');
+const CONCRETE = makeFile(`${DIR}/screen.mthds`, 'screen.mthds',
+    'domain = "rec"\n[pipe.screen]\ntype = "PipeSequence"\n[pipe.build]\ntype = "PipeLLM"\n');
+const CONCEPTS = makeFile(`${DIR}/concepts.mthds`, 'concepts.mthds',
+    'domain = "rec"\n[concept.Scorecard]\ndescription = "x"\n');
+
+describe('resolveDeclaringFile — source-first tier', () => {
+    const files = [SIGNATURE, CONCRETE, CONCEPTS];
+
+    it('resolves an absolute `source` path to its file (over a same-code signature)', () => {
+        // `screen` is declared in BOTH bundle.mthds (signature) and screen.mthds
+        // (concrete). The registry source points at the concrete impl — the win
+        // a pure header scan (which would hit the signature first) cannot make.
+        const owner = resolveDeclaringFile({
+            kind: 'pipe', code: 'screen', domainCode: 'rec',
+            source: `${DIR}/screen.mthds`, files, getLines,
+        });
+        expect(owner?.uri.toString()).toBe(CONCRETE.uri.toString());
+    });
+
+    it('resolves a bare-basename `source` by basename', () => {
+        const owner = resolveDeclaringFile({
+            kind: 'pipe', code: 'screen', source: 'screen.mthds', files, getLines,
+        });
+        expect(owner?.uri.toString()).toBe(CONCRETE.uri.toString());
+    });
+
+    it('resolves a relative-with-subdir `source` on a path-segment boundary', () => {
+        const subFile = makeFile('/root/sub/impl.mthds', 'impl.mthds', 'domain = "d"\n[pipe.p]\n');
+        const decoy = makeFile('/root/other/impl.mthds', 'impl.mthds', 'domain = "d"\n[pipe.p]\n');
+        const owner = resolveDeclaringFile({
+            kind: 'pipe', code: 'p', source: 'sub/impl.mthds', files: [decoy, subFile], getLines,
+        });
+        expect(owner?.uri.toString()).toBe(subFile.uri.toString());
+    });
+
+    it('falls through to the scan when `source` names a file outside the gathered set', () => {
+        // source misses, but `screen` is declared in the gathered files → scan wins.
+        const owner = resolveDeclaringFile({
+            kind: 'pipe', code: 'build', source: '/elsewhere/lib.mthds', files, getLines,
+        });
+        expect(owner?.uri.toString()).toBe(CONCRETE.uri.toString());
+    });
+});
+
+describe('resolveDeclaringFile — scan fallback tier (no source)', () => {
+    it('finds the file declaring `[pipe.<code>]`', () => {
+        const owner = resolveDeclaringFile({
+            kind: 'pipe', code: 'build', files: [SIGNATURE, CONCRETE, CONCEPTS], getLines,
+        });
+        expect(owner?.uri.toString()).toBe(CONCRETE.uri.toString());
+    });
+
+    it('finds the file declaring `[concept.<code>]`', () => {
+        const owner = resolveDeclaringFile({
+            kind: 'concept', code: 'Scorecard', files: [SIGNATURE, CONCRETE, CONCEPTS], getLines,
+        });
+        expect(owner?.uri.toString()).toBe(CONCEPTS.uri.toString());
+    });
+
+    it('returns undefined when no file declares the code', () => {
+        const owner = resolveDeclaringFile({
+            kind: 'pipe', code: 'nonexistent', files: [SIGNATURE, CONCRETE, CONCEPTS], getLines,
+        });
+        expect(owner).toBeUndefined();
+    });
+
+    it('does not match a longer header like `[pipe.screen.outcomes]` for code `screen`', () => {
+        const sub = makeFile(`${DIR}/route.mthds`, 'route.mthds',
+            'domain = "rec"\n[pipe.route]\n[pipe.route.outcomes]\n');
+        const owner = resolveDeclaringFile({ kind: 'pipe', code: 'route', files: [sub], getLines });
+        // Lands on the real `[pipe.route]` header, not the `.outcomes` sub-table.
+        expect(owner?.uri.toString()).toBe(sub.uri.toString());
+        expect(findTableHeaderLine(sub, 'route')).toBe(1);
+    });
+});
+
+describe('findDeclaringFileByScan — domain-disambiguated collision', () => {
+    // Same `[pipe.process]` declared in two files under DIFFERENT domains.
+    const fileA = makeFile(`${DIR}/a.mthds`, 'a.mthds', 'domain = "alpha"\n[pipe.process]\ntype = "PipeLLM"\n');
+    const fileB = makeFile(`${DIR}/b.mthds`, 'b.mthds', 'domain = "beta"\n[pipe.process]\ntype = "PipeLLM"\n');
+
+    it('prefers the file whose domain matches when domainCode is known', () => {
+        const owner = findDeclaringFileByScan('pipe', 'process', [fileA, fileB], 'beta', getLines);
+        expect(owner?.uri.toString()).toBe(fileB.uri.toString());
+    });
+
+    it('falls back to the first match when domainCode is unknown', () => {
+        const owner = findDeclaringFileByScan('pipe', 'process', [fileA, fileB], undefined, getLines);
+        expect(owner?.uri.toString()).toBe(fileA.uri.toString());
+    });
+
+    it('falls back to the first match when no file declares the named domain', () => {
+        const owner = findDeclaringFileByScan('pipe', 'process', [fileA, fileB], 'gamma', getLines);
+        expect(owner?.uri.toString()).toBe(fileA.uri.toString());
+    });
+
+    it('ignores a `domain = ` that appears inside a table section, not at top level', () => {
+        // A nested `domain = ` after the first `[...]` header must not satisfy the
+        // domain check (it scans only the top-level prelude).
+        const nested = makeFile(`${DIR}/c.mthds`, 'c.mthds',
+            '[pipe.process]\ntype = "PipeLLM"\ndomain = "beta"\n');
+        const owner = findDeclaringFileByScan('pipe', 'process', [fileA, nested], 'beta', getLines);
+        // `nested` has no top-level domain, so the real top-level `beta` (none here)
+        // isn't found → first match (fileA) wins.
+        expect(owner?.uri.toString()).toBe(fileA.uri.toString());
+    });
+});
+
+describe('matchSourceFile — path normalization', () => {
+    it('does not misroute a bare source onto a path-qualified sibling', () => {
+        const a = makeFile('/x/foo/a.mthds', 'a.mthds', '');
+        const b = makeFile('/x/bar/a.mthds', 'a.mthds', '');
+        // A bare `a.mthds` matches by basename — first basename match.
+        expect(matchSourceFile('a.mthds', [a, b])?.uri.toString()).toBe(a.uri.toString());
+    });
+
+    it('matches a Windows backslash fsPath from a POSIX relative source', () => {
+        const win = makeFile('C:\\proj\\sub\\a.mthds', 'a.mthds', '');
+        expect(matchSourceFile('sub/a.mthds', [win])?.uri.toString()).toBe(win.uri.toString());
+    });
+
+    it('returns undefined when nothing matches', () => {
+        expect(matchSourceFile('/nope/x.mthds', [SIGNATURE])).toBeUndefined();
+    });
+});
+
+/** Helper: the 0-based line of `[pipe.<code>]` in a file, for header-placement assertions. */
+function findTableHeaderLine(file: BundleFile, code: string): number {
+    const lines = getLines(file);
+    const re = new RegExp(`^\\s*\\[pipe\\.${code}\\]`);
+    return lines.findIndex(l => re.test(l));
+}

--- a/editors/vscode/src/pipelex/__tests__/bundleResolution.test.ts
+++ b/editors/vscode/src/pipelex/__tests__/bundleResolution.test.ts
@@ -65,6 +65,14 @@ describe('resolveDeclaringFile — source-first tier', () => {
         });
         expect(owner?.uri.toString()).toBe(CONCRETE.uri.toString());
     });
+
+    it('falls through to the scan when `source` names a file without the declaration header', () => {
+        const stale = makeFile(`${DIR}/stale.mthds`, 'stale.mthds', 'domain = "rec"\n[pipe.other]\n');
+        const owner = resolveDeclaringFile({
+            kind: 'pipe', code: 'build', source: `${DIR}/stale.mthds`, files: [SIGNATURE, stale, CONCRETE], getLines,
+        });
+        expect(owner?.uri.toString()).toBe(CONCRETE.uri.toString());
+    });
 });
 
 describe('resolveDeclaringFile — scan fallback tier (no source)', () => {
@@ -129,14 +137,20 @@ describe('findDeclaringFileByScan — domain-disambiguated collision', () => {
         // isn't found → first match (fileA) wins.
         expect(owner?.uri.toString()).toBe(fileA.uri.toString());
     });
+
+    it('does not accept mismatched quotes in a top-level domain declaration', () => {
+        const malformed = makeFile(`${DIR}/malformed.mthds`, 'malformed.mthds',
+            'domain = "beta\'\n[pipe.process]\ntype = "PipeLLM"\n');
+        const owner = findDeclaringFileByScan('pipe', 'process', [fileA, malformed], 'beta', getLines);
+        expect(owner?.uri.toString()).toBe(fileA.uri.toString());
+    });
 });
 
 describe('matchSourceFile — path normalization', () => {
-    it('does not misroute a bare source onto a path-qualified sibling', () => {
+    it('does not guess when a bare source basename is ambiguous', () => {
         const a = makeFile('/x/foo/a.mthds', 'a.mthds', '');
         const b = makeFile('/x/bar/a.mthds', 'a.mthds', '');
-        // A bare `a.mthds` matches by basename — first basename match.
-        expect(matchSourceFile('a.mthds', [a, b])?.uri.toString()).toBe(a.uri.toString());
+        expect(matchSourceFile('a.mthds', [a, b])).toBeUndefined();
     });
 
     it('matches a Windows backslash fsPath from a POSIX relative source', () => {

--- a/editors/vscode/src/pipelex/__tests__/crossFileDiagnostics.test.ts
+++ b/editors/vscode/src/pipelex/__tests__/crossFileDiagnostics.test.ts
@@ -66,6 +66,20 @@ describe('buildBundleDiagnostics — owner resolution', () => {
         expect(result[0].uri.toString()).toBe(SIBLING.uri.toString());
     });
 
+    it('places a same-code pipe error on the file whose domain matches the error', () => {
+        const alpha = makeFile('alpha.mthds', 'domain = "alpha"\n[pipe.process]\ntype = "PipeLLM"\n');
+        const beta = makeFile('beta.mthds', 'domain = "beta"\n[pipe.process]\ntype = "PipeLLM"\n');
+        const result = buildBundleDiagnostics({
+            errors: [{ category: 'pipe_factory', message: 'beta process broke', pipe_code: 'process', domain_code: 'beta' }],
+            files: [alpha, beta],
+            primaryUri: alpha.uri as any,
+            diagnosticSource: 'pipelex',
+        });
+        expect(result).toHaveLength(1);
+        expect(result[0].uri.toString()).toBe(beta.uri.toString());
+        expect(result[0].diagnostics[0].range.start.line).toBe(1);
+    });
+
     it('falls back to the concept-declaring file when only concept_code is known', () => {
         const result = build([{ category: 'pipe_factory', message: 'Foo missing', concept_code: 'Foo' }]);
         expect(result[0].uri.toString()).toBe(SIBLING.uri.toString());

--- a/editors/vscode/src/pipelex/__tests__/graphPrimary.test.ts
+++ b/editors/vscode/src/pipelex/__tests__/graphPrimary.test.ts
@@ -6,7 +6,12 @@ vi.mock('vscode', () => ({
     },
 }));
 
-import { hasTopLevelMainPipe, selectGraphPrimaryFile } from '../validation/graphPrimary';
+vi.mock('../validation/bundleGather', () => ({
+    gatherBundleFiles: vi.fn(),
+}));
+
+import { hasTopLevelMainPipe, resolveGraphPrimaryBundle, selectGraphPrimaryFile } from '../validation/graphPrimary';
+import * as bundleGather from '../validation/bundleGather';
 import type { BundleFile } from '../validation/backend';
 
 const DIR = '/project/methods';
@@ -61,5 +66,12 @@ describe('graph primary resolution', () => {
     it('only treats pre-table main_pipe as top-level', () => {
         expect(hasTopLevelMainPipe('domain = "d"\nmain_pipe = "run"\n[pipe.run]\n')).toBe(true);
         expect(hasTopLevelMainPipe('domain = "d"\n[pipe.run]\nmain_pipe = "run"\n')).toBe(false);
+    });
+
+    it('propagates gather failures instead of returning an empty API bundle', async () => {
+        const opened = uri(`${DIR}/helper.mthds`);
+        vi.mocked(bundleGather.gatherBundleFiles).mockRejectedValueOnce(new Error('disk gone'));
+
+        await expect(resolveGraphPrimaryBundle(opened)).rejects.toThrow('disk gone');
     });
 });

--- a/editors/vscode/src/pipelex/__tests__/graphPrimary.test.ts
+++ b/editors/vscode/src/pipelex/__tests__/graphPrimary.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('vscode', () => ({
+    Uri: {
+        file: (p: string) => ({ fsPath: p, scheme: 'file', toString: () => `file://${p}` }),
+    },
+}));
+
+import { hasTopLevelMainPipe, selectGraphPrimaryFile } from '../validation/graphPrimary';
+import type { BundleFile } from '../validation/backend';
+
+const DIR = '/project/methods';
+
+function uri(fsPath: string) {
+    return { fsPath, scheme: 'file', toString: () => `file://${fsPath}` } as any;
+}
+
+function makeFile(name: string, content: string): BundleFile {
+    return { uri: uri(`${DIR}/${name}`), name, content };
+}
+
+describe('graph primary resolution', () => {
+    it('keeps the opened file when it declares top-level main_pipe', () => {
+        const opened = makeFile('helper.mthds', 'domain = "d"\nmain_pipe = "run"\n[pipe.run]\n');
+        const bundle = makeFile('bundle.mthds', 'domain = "d"\nmain_pipe = "other"\n[pipe.other]\n');
+
+        const selected = selectGraphPrimaryFile(opened.uri, [opened, bundle]);
+
+        expect(selected?.uri.toString()).toBe(opened.uri.toString());
+    });
+
+    it('selects sibling bundle.mthds when the opened file has no main_pipe', () => {
+        const opened = makeFile('helper.mthds', 'domain = "d"\n[pipe.helper]\n');
+        const bundle = makeFile('bundle.mthds', 'domain = "d"\nmain_pipe = "run"\n[pipe.run]\n');
+        const other = makeFile('z_main.mthds', 'domain = "d"\nmain_pipe = "other"\n[pipe.other]\n');
+
+        const selected = selectGraphPrimaryFile(opened.uri, [opened, bundle, other]);
+
+        expect(selected?.uri.toString()).toBe(bundle.uri.toString());
+    });
+
+    it('selects the first gathered sibling with main_pipe when bundle.mthds has none', () => {
+        const opened = makeFile('helper.mthds', 'domain = "d"\n[pipe.helper]\n');
+        const first = makeFile('alpha.mthds', 'domain = "d"\nmain_pipe = "a"\n[pipe.a]\n');
+        const second = makeFile('zeta.mthds', 'domain = "d"\nmain_pipe = "z"\n[pipe.z]\n');
+
+        const selected = selectGraphPrimaryFile(opened.uri, [opened, first, second]);
+
+        expect(selected?.uri.toString()).toBe(first.uri.toString());
+    });
+
+    it('falls back to the opened file when no sibling declares main_pipe', () => {
+        const opened = makeFile('helper.mthds', 'domain = "d"\n[pipe.helper]\n');
+        const sibling = makeFile('concepts.mthds', 'domain = "d"\n[concept.Thing]\n');
+
+        const selected = selectGraphPrimaryFile(opened.uri, [opened, sibling]);
+
+        expect(selected?.uri.toString()).toBe(opened.uri.toString());
+    });
+
+    it('only treats pre-table main_pipe as top-level', () => {
+        expect(hasTopLevelMainPipe('domain = "d"\nmain_pipe = "run"\n[pipe.run]\n')).toBe(true);
+        expect(hasTopLevelMainPipe('domain = "d"\n[pipe.run]\nmain_pipe = "run"\n')).toBe(false);
+    });
+});

--- a/editors/vscode/src/pipelex/__tests__/methodGraphPanel.test.ts
+++ b/editors/vscode/src/pipelex/__tests__/methodGraphPanel.test.ts
@@ -1353,6 +1353,11 @@ describe('MethodGraphPanel', () => {
 
         const panel = new MethodGraphPanel(mockOutput(), makeExtensionUri());
         const uri = makeUri('/project/methods/bundle.mthds');
+        const helperUri = makeUri('/project/methods/helper.mthds');
+        mockState.bundleFiles = [
+            { uri, name: 'bundle.mthds', content: 'domain = "rec"\nmain_pipe = "main"\n[pipe.main]\n' },
+            { uri: helperUri, name: 'helper.mthds', content: 'domain = "rec"\n[pipe.helper]\n' },
+        ];
         panel.show(uri);
         await new Promise(r => setTimeout(r, 20));
 
@@ -1362,12 +1367,75 @@ describe('MethodGraphPanel', () => {
         expect(editorChangeHandler).not.toBeNull();
 
         await editorChangeHandler!({
-            document: { languageId: 'mthds', uri: makeUri('/project/methods/helper.mthds') },
+            document: { languageId: 'mthds', uri: helperUri },
             viewColumn: 1,
         });
 
         expect(processUtils.spawnCli).not.toHaveBeenCalled();
         expect(mockState.mockPanel.title).toBe(originalTitle);
+        panel.dispose();
+    });
+
+    it('onDidChangeActiveTextEditor refreshes when a same-directory file has its own graph primary', async () => {
+        const processUtils = await import('../validation/processUtils');
+
+        const panel = new MethodGraphPanel(mockOutput(), makeExtensionUri());
+        const uri = makeUri('/project/methods/bundle.mthds');
+        const otherUri = makeUri('/project/methods/other.mthds');
+        mockState.bundleFiles = [
+            { uri, name: 'bundle.mthds', content: 'domain = "rec"\nmain_pipe = "main"\n[pipe.main]\n' },
+            { uri: otherUri, name: 'other.mthds', content: 'domain = "rec"\nmain_pipe = "other"\n[pipe.other]\n' },
+        ];
+        panel.show(uri);
+        await new Promise(r => setTimeout(r, 20));
+
+        vi.mocked(processUtils.spawnCli).mockClear();
+        const editorChangeHandler = mockState.onEditorChangeHandler;
+        expect(editorChangeHandler).not.toBeNull();
+
+        await editorChangeHandler!({
+            document: { languageId: 'mthds', uri: otherUri },
+            viewColumn: 1,
+        });
+
+        await vi.waitFor(() => {
+            expect(processUtils.spawnCli).toHaveBeenCalled();
+        });
+        expect(mockState.mockPanel.title).toBe('Method Graph — other.mthds');
+        panel.dispose();
+    });
+
+    it('onDidChangeActiveTextEditor switches from graphspec JSON to a same-directory mthds graph', async () => {
+        const processUtils = await import('../validation/processUtils');
+
+        const panel = new MethodGraphPanel(mockOutput(), makeExtensionUri());
+        const jsonUri = makeUri('/project/methods/run.json');
+        mockState.openTextDocuments = [
+            {
+                uri: jsonUri,
+                getText: () => JSON.stringify({ meta: { format: 'mthds' }, nodes: [], edges: [] }),
+            },
+        ];
+        panel.showGraphspecJson(jsonUri);
+        await new Promise(r => setTimeout(r, 20));
+
+        const mthdsUri = makeUri('/project/methods/bundle.mthds');
+        mockState.bundleFiles = [
+            { uri: mthdsUri, name: 'bundle.mthds', content: 'domain = "rec"\nmain_pipe = "main"\n[pipe.main]\n' },
+        ];
+        vi.mocked(processUtils.spawnCli).mockClear();
+        const editorChangeHandler = mockState.onEditorChangeHandler;
+        expect(editorChangeHandler).not.toBeNull();
+
+        await editorChangeHandler!({
+            document: { languageId: 'mthds', uri: mthdsUri },
+            viewColumn: 1,
+        });
+
+        await vi.waitFor(() => {
+            expect(processUtils.spawnCli).toHaveBeenCalled();
+        });
+        expect(mockState.mockPanel.title).toBe('Method Graph — bundle.mthds');
         panel.dispose();
     });
 

--- a/editors/vscode/src/pipelex/__tests__/methodGraphPanel.test.ts
+++ b/editors/vscode/src/pipelex/__tests__/methodGraphPanel.test.ts
@@ -776,9 +776,6 @@ describe('MethodGraphPanel', () => {
         const primaryUri = makeUri('/project/methods/bundle.mthds');
         const siblingUri = makeUri('/project/methods/helpers.mthds');
         let resolveGather: ((files: any[]) => void) | undefined;
-        vi.mocked(bundleGather.gatherBundleFiles).mockImplementationOnce(() => new Promise(resolve => {
-            resolveGather = resolve;
-        }));
 
         const graphspec = {
             meta: { format: 'mthds' },
@@ -791,6 +788,9 @@ describe('MethodGraphPanel', () => {
         const panel = new MethodGraphPanel(mockOutput(), makeExtensionUri());
         const messageHandler = await showGraphWithSpec(panel, primaryUri, graphspec);
 
+        vi.mocked(bundleGather.gatherBundleFiles).mockImplementationOnce(() => new Promise(resolve => {
+            resolveGather = resolve;
+        }));
         vi.mocked(vscode.workspace.openTextDocument).mockClear();
         messageHandler({ type: 'navigateToPipe', pipeCode: 'helper', nodeId: 'node-helper', domainCode: 'rec' });
         await vi.waitFor(() => {
@@ -864,6 +864,45 @@ describe('MethodGraphPanel', () => {
         const idx = args.indexOf('--library-dir');
         expect(idx).toBeGreaterThan(-1);
         expect(args[idx + 1]).toBe('/project/methods');
+        panel.dispose();
+    });
+
+    it('refresh() analyzes sibling bundle.mthds when opened file has no main_pipe', async () => {
+        const processUtils = await import('../validation/processUtils');
+        const graphspec = { nodes: [], edges: [] };
+        mockState.spawnCliResult = {
+            stdout: JSON.stringify({ graphspec, pipe_code: 'main' }),
+            stderr: '',
+        };
+        const helperUri = makeUri('/project/methods/helper.mthds');
+        const bundleUri = makeUri('/project/methods/bundle.mthds');
+        mockState.bundleFiles = [
+            { uri: helperUri, name: 'helper.mthds', content: 'domain = "rec"\n[pipe.helper]\n' },
+            { uri: bundleUri, name: 'bundle.mthds', content: 'domain = "rec"\nmain_pipe = "main"\n[pipe.main]\n' },
+        ];
+
+        const panel = new MethodGraphPanel(mockOutput(), makeExtensionUri());
+        panel.show(helperUri);
+        await new Promise(r => setTimeout(r, 50));
+
+        const args = vi.mocked(processUtils.spawnCli).mock.calls[0][1] as string[];
+        expect(args).toEqual(expect.arrayContaining([
+            'validate',
+            'bundle',
+            '/project/methods/bundle.mthds',
+            '--library-dir',
+            '/project/methods',
+        ]));
+
+        const messageHandler = mockState.mockWebview.onDidReceiveMessage.mock.calls[0][0];
+        messageHandler({ type: 'webviewReady' });
+        expect(mockState.mockWebview.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'setData',
+                uri: helperUri.toString(),
+                graphspec,
+            }),
+        );
         panel.dispose();
     });
 
@@ -1122,13 +1161,13 @@ describe('MethodGraphPanel', () => {
 
     it('still renders the error list when gathering bundle files fails (no unhandled rejection)', async () => {
         const bundleGather = await import('../validation/bundleGather');
-        vi.mocked(bundleGather.gatherBundleFiles).mockRejectedValueOnce(new Error('disk gone'));
 
         const output = mockOutput();
         const panel = new MethodGraphPanel(output, makeExtensionUri());
         const uri = makeUri('/project/methods/main.mthds');
         panel.show(uri);
         await new Promise(r => setTimeout(r, 20));
+        vi.mocked(bundleGather.gatherBundleFiles).mockRejectedValueOnce(new Error('disk gone'));
 
         const range = { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } };
         mockState.errorLocations = [

--- a/editors/vscode/src/pipelex/__tests__/methodGraphPanel.test.ts
+++ b/editors/vscode/src/pipelex/__tests__/methodGraphPanel.test.ts
@@ -176,6 +176,7 @@ vi.mock('../validation/sourceLocator', () => {
     const headerRe = (kind: string, code: string) =>
         new RegExp(`^\\s*\\[${kind}\\.${code.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\]`);
     return {
+        escapeRegex: (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
         findTableHeader: vi.fn((doc: any, kind: string, code: string) => {
             const re = headerRe(kind, code);
             for (let i = 0; i < doc.lineCount; i++) {
@@ -581,6 +582,138 @@ describe('MethodGraphPanel', () => {
         panel.dispose();
     });
 
+    it('navigateToPipe reads domain-less registry sources from `.pipe` keys', async () => {
+        const vscode = await import('vscode');
+        const primaryUri = makeUri('/project/methods/bundle.mthds');
+        const siblingUri = makeUri('/project/methods/screen.mthds');
+
+        const graphspec = {
+            meta: { format: 'mthds' },
+            nodes: [{ id: 'node-screen', pipe_code: 'screen', kind: 'controller' }],
+            edges: [],
+            pipe_registry: {
+                '.screen': { code: 'screen', domain_code: '', source: '/project/methods/screen.mthds' },
+            },
+        };
+        mockState.docContents['/project/methods/screen.mthds'] =
+            '[pipe.screen]\ntype = "PipeSequence"\n';
+        mockState.bundleFiles = [
+            { uri: primaryUri, name: 'bundle.mthds', content: '[pipe.screen]\ntype = "PipeSignature"\n' },
+            { uri: siblingUri, name: 'screen.mthds', content: mockState.docContents['/project/methods/screen.mthds'] },
+        ];
+
+        const panel = new MethodGraphPanel(mockOutput(), makeExtensionUri());
+        const messageHandler = await showGraphWithSpec(panel, primaryUri, graphspec);
+
+        vi.mocked(vscode.workspace.openTextDocument).mockClear();
+        messageHandler({ type: 'navigateToPipe', pipeCode: 'screen', nodeId: 'node-screen', domainCode: '' });
+        await new Promise(r => setTimeout(r, 20));
+
+        expect(vscode.workspace.openTextDocument).toHaveBeenCalledWith(siblingUri);
+        panel.dispose();
+    });
+
+    it('navigateToPipe uses the clicked node domain when two nodes share a pipe_code', async () => {
+        const vscode = await import('vscode');
+        const primaryUri = makeUri('/project/methods/bundle.mthds');
+        const alphaUri = makeUri('/project/methods/alpha.mthds');
+        const betaUri = makeUri('/project/methods/beta.mthds');
+
+        const graphspec = {
+            meta: { format: 'mthds' },
+            nodes: [
+                { id: 'alpha-process', pipe_code: 'process', domain_code: 'alpha', kind: 'operator' },
+                { id: 'beta-process', pipe_code: 'process', domain_code: 'beta', kind: 'operator' },
+            ],
+            edges: [],
+            pipe_registry: {
+                'alpha.process': { code: 'process', domain_code: 'alpha', source: '/project/methods/alpha.mthds' },
+                'beta.process': { code: 'process', domain_code: 'beta', source: '/project/methods/beta.mthds' },
+            },
+        };
+        mockState.docContents['/project/methods/alpha.mthds'] = 'domain = "alpha"\n[pipe.process]\n';
+        mockState.docContents['/project/methods/beta.mthds'] = 'domain = "beta"\n[pipe.process]\n';
+        mockState.bundleFiles = [
+            { uri: primaryUri, name: 'bundle.mthds', content: 'domain = "root"\n[pipe.main]\n' },
+            { uri: alphaUri, name: 'alpha.mthds', content: mockState.docContents['/project/methods/alpha.mthds'] },
+            { uri: betaUri, name: 'beta.mthds', content: mockState.docContents['/project/methods/beta.mthds'] },
+        ];
+
+        const panel = new MethodGraphPanel(mockOutput(), makeExtensionUri());
+        const messageHandler = await showGraphWithSpec(panel, primaryUri, graphspec);
+
+        vi.mocked(vscode.workspace.openTextDocument).mockClear();
+        messageHandler({ type: 'navigateToPipe', pipeCode: 'process', nodeId: 'beta-process', domainCode: 'beta' });
+        await new Promise(r => setTimeout(r, 20));
+
+        expect(vscode.workspace.openTextDocument).toHaveBeenCalledWith(betaUri);
+        panel.dispose();
+    });
+
+    it('navigateToPipe does not use a domainless registry source for a domain-specific click', async () => {
+        const vscode = await import('vscode');
+        const primaryUri = makeUri('/project/methods/bundle.mthds');
+        const domainlessUri = makeUri('/project/methods/shared.mthds');
+        const betaUri = makeUri('/project/methods/beta.mthds');
+
+        const graphspec = {
+            meta: { format: 'mthds' },
+            nodes: [{ id: 'beta-process', pipe_code: 'process', domain_code: 'beta', kind: 'operator' }],
+            edges: [],
+            pipe_registry: {
+                '.process': { code: 'process', domain_code: '', source: '/project/methods/shared.mthds' },
+            },
+        };
+        mockState.docContents['/project/methods/shared.mthds'] = '[pipe.process]\n';
+        mockState.docContents['/project/methods/beta.mthds'] = 'domain = "beta"\n[pipe.process]\n';
+        mockState.bundleFiles = [
+            { uri: primaryUri, name: 'bundle.mthds', content: 'domain = "root"\n[pipe.main]\n' },
+            { uri: domainlessUri, name: 'shared.mthds', content: mockState.docContents['/project/methods/shared.mthds'] },
+            { uri: betaUri, name: 'beta.mthds', content: mockState.docContents['/project/methods/beta.mthds'] },
+        ];
+
+        const panel = new MethodGraphPanel(mockOutput(), makeExtensionUri());
+        const messageHandler = await showGraphWithSpec(panel, primaryUri, graphspec);
+
+        vi.mocked(vscode.workspace.openTextDocument).mockClear();
+        messageHandler({ type: 'navigateToPipe', pipeCode: 'process', nodeId: 'beta-process', domainCode: 'beta' });
+        await new Promise(r => setTimeout(r, 20));
+
+        expect(vscode.workspace.openTextDocument).toHaveBeenCalledWith(betaUri);
+        expect(vscode.workspace.openTextDocument).not.toHaveBeenCalledWith(domainlessUri);
+        panel.dispose();
+    });
+
+    it('navigateToPipe falls back to the declaration scan when registry `source` is stale', async () => {
+        const vscode = await import('vscode');
+        const primaryUri = makeUri('/project/methods/bundle.mthds');
+        const staleUri = makeUri('/project/methods/stale.mthds');
+        const siblingUri = makeUri('/project/methods/helpers.mthds');
+
+        const graphspec = {
+            meta: { format: 'mthds' },
+            nodes: [{ id: 'node-build', pipe_code: 'build', domain_code: 'rec', kind: 'operator' }],
+            edges: [],
+            pipe_registry: { 'rec.build': { code: 'build', domain_code: 'rec', source: '/project/methods/stale.mthds' } },
+        };
+        mockState.docContents['/project/methods/helpers.mthds'] = 'domain = "rec"\n[pipe.build]\ntype = "PipeLLM"\n';
+        mockState.bundleFiles = [
+            { uri: primaryUri, name: 'bundle.mthds', content: 'domain = "rec"\n[pipe.main]\n' },
+            { uri: staleUri, name: 'stale.mthds', content: 'domain = "rec"\n[pipe.other]\n' },
+            { uri: siblingUri, name: 'helpers.mthds', content: mockState.docContents['/project/methods/helpers.mthds'] },
+        ];
+
+        const panel = new MethodGraphPanel(mockOutput(), makeExtensionUri());
+        const messageHandler = await showGraphWithSpec(panel, primaryUri, graphspec);
+
+        vi.mocked(vscode.workspace.openTextDocument).mockClear();
+        messageHandler({ type: 'navigateToPipe', pipeCode: 'build', nodeId: 'node-build', domainCode: 'rec' });
+        await new Promise(r => setTimeout(r, 20));
+
+        expect(vscode.workspace.openTextDocument).toHaveBeenCalledWith(siblingUri);
+        panel.dispose();
+    });
+
     it('navigateToPipe keeps a primary-declared pipe on the primary file (single-file regression)', async () => {
         const vscode = await import('vscode');
         const primaryUri = makeUri('/project/methods/bundle.mthds');
@@ -634,6 +767,43 @@ describe('MethodGraphPanel', () => {
 
         // No source → scan locates `[pipe.helper]` in the sibling.
         expect(vscode.workspace.openTextDocument).toHaveBeenCalledWith(siblingUri);
+        panel.dispose();
+    });
+
+    it('navigateToPipe aborts if the panel switches files while gathering siblings', async () => {
+        const vscode = await import('vscode');
+        const bundleGather = await import('../validation/bundleGather');
+        const primaryUri = makeUri('/project/methods/bundle.mthds');
+        const siblingUri = makeUri('/project/methods/helpers.mthds');
+        let resolveGather: ((files: any[]) => void) | undefined;
+        vi.mocked(bundleGather.gatherBundleFiles).mockImplementationOnce(() => new Promise(resolve => {
+            resolveGather = resolve;
+        }));
+
+        const graphspec = {
+            meta: { format: 'mthds' },
+            nodes: [{ id: 'node-helper', pipe_code: 'helper', domain_code: 'rec', kind: 'operator' }],
+            edges: [],
+            pipe_registry: { 'rec.helper': { code: 'helper', domain_code: 'rec', source: '/project/methods/helpers.mthds' } },
+        };
+        mockState.docContents['/project/methods/helpers.mthds'] = 'domain = "rec"\n[pipe.helper]\n';
+
+        const panel = new MethodGraphPanel(mockOutput(), makeExtensionUri());
+        const messageHandler = await showGraphWithSpec(panel, primaryUri, graphspec);
+
+        vi.mocked(vscode.workspace.openTextDocument).mockClear();
+        messageHandler({ type: 'navigateToPipe', pipeCode: 'helper', nodeId: 'node-helper', domainCode: 'rec' });
+        await vi.waitFor(() => {
+            expect(resolveGather).toBeDefined();
+        });
+        (panel as any).currentUri = makeUri('/project/methods/other.mthds');
+        resolveGather!([
+            { uri: primaryUri, name: 'bundle.mthds', content: 'domain = "rec"\n[pipe.main]\n' },
+            { uri: siblingUri, name: 'helpers.mthds', content: mockState.docContents['/project/methods/helpers.mthds'] },
+        ]);
+        await new Promise(r => setTimeout(r, 20));
+
+        expect(vscode.workspace.openTextDocument).not.toHaveBeenCalled();
         panel.dispose();
     });
 

--- a/editors/vscode/src/pipelex/__tests__/methodGraphPanel.test.ts
+++ b/editors/vscode/src/pipelex/__tests__/methodGraphPanel.test.ts
@@ -40,6 +40,9 @@ const mockState = vi.hoisted(() => {
         bundleFiles: [] as any[],
         errorLocations: [] as any[],
         openTextDocuments: [] as any[],
+        // Per-fsPath file contents for the URI-aware openTextDocument mock, so a
+        // resolved sibling opens with real text the faithful findTableHeader can scan.
+        docContents: {} as Record<string, string>,
         // Event handler captures
         onSaveHandler: null as ((doc: any) => void) | null,
         onEditorChangeHandler: null as ((editor: any) => void) | null,
@@ -90,13 +93,30 @@ vi.mock('vscode', () => ({
             return { dispose: vi.fn() };
         }),
         getWorkspaceFolder: () => ({ uri: { fsPath: '/workspace' } }),
-        openTextDocument: vi.fn(() => Promise.resolve({
-            lineCount: 10,
-            lineAt: (i: number) => ({
-                text: i === 3 ? '[pipe.my_pipe]' : '',
-                range: { start: { line: i, character: 0 }, end: { line: i, character: 14 } },
-            }),
-        })),
+        openTextDocument: vi.fn((uriArg: any) => {
+            // URI-aware: when a fixture registers content for this path, build a
+            // document from it (so a resolved sibling opens with its real text);
+            // otherwise fall back to the legacy single-doc shape used by older tests.
+            const fsPath = uriArg?.fsPath ?? uriArg;
+            const content = mockState.docContents[fsPath];
+            if (content != null) {
+                const lines = content.split('\n');
+                return Promise.resolve({
+                    lineCount: lines.length,
+                    lineAt: (i: number) => ({
+                        text: lines[i] ?? '',
+                        range: { start: { line: i, character: 0 }, end: { line: i, character: (lines[i] ?? '').length } },
+                    }),
+                });
+            }
+            return Promise.resolve({
+                lineCount: 10,
+                lineAt: (i: number) => ({
+                    text: i === 3 ? '[pipe.my_pipe]' : '',
+                    range: { start: { line: i, character: 0 }, end: { line: i, character: 14 } },
+                }),
+            });
+        }),
     },
     window: {
         // Default to a dark editor theme; tests can override via mockState.activeColorThemeKind.
@@ -149,12 +169,29 @@ vi.mock('fs', () => ({
     readFileSync: vi.fn(() => mockState.readFileSyncResult),
 }));
 
-vi.mock('../validation/sourceLocator', () => ({
-    findTableHeader: vi.fn((_doc: any, _kind: string, code: string) => {
-        if (code === 'my_pipe') return 3;
-        return -1;
-    }),
-}));
+// Faithful (vscode-free) re-implementations: findTableHeader scans the opened
+// document, findTableHeaderInLines scans raw lines — the latter is what the real
+// resolveDeclaringFile (unmocked here) calls during its scan-fallback tier.
+vi.mock('../validation/sourceLocator', () => {
+    const headerRe = (kind: string, code: string) =>
+        new RegExp(`^\\s*\\[${kind}\\.${code.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\]`);
+    return {
+        findTableHeader: vi.fn((doc: any, kind: string, code: string) => {
+            const re = headerRe(kind, code);
+            for (let i = 0; i < doc.lineCount; i++) {
+                if (re.test(doc.lineAt(i).text)) return i;
+            }
+            return -1;
+        }),
+        findTableHeaderInLines: vi.fn((lines: string[], kind: string, code: string) => {
+            const re = headerRe(kind, code);
+            for (let i = 0; i < lines.length; i++) {
+                if (re.test(lines[i])) return i;
+            }
+            return -1;
+        }),
+    };
+});
 
 vi.mock('../validation/bundleGather', () => ({
     gatherBundleFiles: vi.fn(() => Promise.resolve(mockState.bundleFiles)),
@@ -213,6 +250,7 @@ describe('MethodGraphPanel', () => {
         mockState.bundleFiles = [];
         mockState.errorLocations = [];
         mockState.openTextDocuments = [];
+        mockState.docContents = {};
         mockState.activeColorThemeKind = 2; // ColorThemeKind.Dark
     });
 
@@ -488,6 +526,143 @@ describe('MethodGraphPanel', () => {
         // Should have opened the document and shown it
         expect(vscode.workspace.openTextDocument).toHaveBeenCalledWith(uri);
         expect(vscode.window.showTextDocument).toHaveBeenCalled();
+        panel.dispose();
+    });
+
+    // --- Cross-file pipe navigation (source-first, scan-as-fallback) ---
+
+    // Drive a graphspec (with a pipe_registry) onto the panel via the normal CLI
+    // path so `currentGraphspec` is retained, then return the message handler.
+    async function showGraphWithSpec(panel: MethodGraphPanel, primaryUri: any, graphspec: any) {
+        mockState.spawnCliResult = { stdout: JSON.stringify({ graphspec, pipe_code: 'x' }), stderr: '' };
+        panel.show(primaryUri);
+        await new Promise(r => setTimeout(r, 50));
+        const messageHandler = mockState.mockWebview.onDidReceiveMessage.mock.calls[0][0];
+        messageHandler({ type: 'webviewReady' });
+        return messageHandler;
+    }
+
+    it('navigateToPipe opens the concrete sibling named by registry `source` (cross-file)', async () => {
+        const vscode = await import('vscode');
+        const primaryUri = makeUri('/project/methods/bundle.mthds');
+        const siblingUri = makeUri('/project/methods/screen.mthds');
+
+        // `screen` is declared in BOTH the primary (signature) and the sibling
+        // (concrete). The registry `source` points at the concrete sibling — the
+        // win a pure scan (which hits the primary signature first) cannot make.
+        const graphspec = {
+            meta: { format: 'mthds' },
+            nodes: [{ pipe_code: 'screen', domain_code: 'rec', kind: 'controller' }],
+            edges: [],
+            pipe_registry: {
+                'rec.screen': { code: 'screen', domain_code: 'rec', source: '/project/methods/screen.mthds' },
+            },
+        };
+        mockState.docContents['/project/methods/screen.mthds'] =
+            'domain = "rec"\n[pipe.screen]\ntype = "PipeSequence"\n';
+        mockState.bundleFiles = [
+            { uri: primaryUri, name: 'bundle.mthds', content: 'domain = "rec"\n[pipe.screen]\ntype = "PipeSignature"\n' },
+            { uri: siblingUri, name: 'screen.mthds', content: mockState.docContents['/project/methods/screen.mthds'] },
+        ];
+
+        const panel = new MethodGraphPanel(mockOutput(), makeExtensionUri());
+        const messageHandler = await showGraphWithSpec(panel, primaryUri, graphspec);
+
+        vi.mocked(vscode.workspace.openTextDocument).mockClear();
+        messageHandler({ type: 'navigateToPipe', pipeCode: 'screen' });
+        await new Promise(r => setTimeout(r, 20));
+
+        // Opened the CONCRETE sibling, not the signature in the primary, and revealed it beside.
+        expect(vscode.workspace.openTextDocument).toHaveBeenCalledWith(siblingUri);
+        expect(vscode.window.showTextDocument).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ viewColumn: 1, preserveFocus: false }),
+        );
+        panel.dispose();
+    });
+
+    it('navigateToPipe keeps a primary-declared pipe on the primary file (single-file regression)', async () => {
+        const vscode = await import('vscode');
+        const primaryUri = makeUri('/project/methods/bundle.mthds');
+
+        const graphspec = {
+            meta: { format: 'mthds' },
+            nodes: [{ pipe_code: 'main', domain_code: 'rec', kind: 'controller' }],
+            edges: [],
+            pipe_registry: { 'rec.main': { code: 'main', domain_code: 'rec', source: '/project/methods/bundle.mthds' } },
+        };
+        mockState.docContents['/project/methods/bundle.mthds'] = 'domain = "rec"\n[pipe.main]\ntype = "PipeLLM"\n';
+        mockState.bundleFiles = [
+            { uri: primaryUri, name: 'bundle.mthds', content: mockState.docContents['/project/methods/bundle.mthds'] },
+        ];
+
+        const panel = new MethodGraphPanel(mockOutput(), makeExtensionUri());
+        const messageHandler = await showGraphWithSpec(panel, primaryUri, graphspec);
+
+        vi.mocked(vscode.workspace.openTextDocument).mockClear();
+        messageHandler({ type: 'navigateToPipe', pipeCode: 'main' });
+        await new Promise(r => setTimeout(r, 20));
+
+        expect(vscode.workspace.openTextDocument).toHaveBeenCalledWith(primaryUri);
+        panel.dispose();
+    });
+
+    it('navigateToPipe falls back to the declaration scan when the registry omits `source` (older CLI)', async () => {
+        const vscode = await import('vscode');
+        const primaryUri = makeUri('/project/methods/bundle.mthds');
+        const siblingUri = makeUri('/project/methods/helpers.mthds');
+
+        // Registry entry WITHOUT a `source` — the feature-detection degradation path.
+        const graphspec = {
+            meta: { format: 'mthds' },
+            nodes: [{ pipe_code: 'helper', domain_code: 'rec', kind: 'operator' }],
+            edges: [],
+            pipe_registry: { 'rec.helper': { code: 'helper', domain_code: 'rec' } },
+        };
+        mockState.docContents['/project/methods/helpers.mthds'] = 'domain = "rec"\n[pipe.helper]\ntype = "PipeLLM"\n';
+        mockState.bundleFiles = [
+            { uri: primaryUri, name: 'bundle.mthds', content: 'domain = "rec"\n[pipe.main]\n' },
+            { uri: siblingUri, name: 'helpers.mthds', content: mockState.docContents['/project/methods/helpers.mthds'] },
+        ];
+
+        const panel = new MethodGraphPanel(mockOutput(), makeExtensionUri());
+        const messageHandler = await showGraphWithSpec(panel, primaryUri, graphspec);
+
+        vi.mocked(vscode.workspace.openTextDocument).mockClear();
+        messageHandler({ type: 'navigateToPipe', pipeCode: 'helper' });
+        await new Promise(r => setTimeout(r, 20));
+
+        // No source → scan locates `[pipe.helper]` in the sibling.
+        expect(vscode.workspace.openTextDocument).toHaveBeenCalledWith(siblingUri);
+        panel.dispose();
+    });
+
+    it('navigateToPipe logs and stays put for a synthesized pipe with no declaring file', async () => {
+        const output = mockOutput();
+        const primaryUri = makeUri('/project/methods/bundle.mthds');
+
+        // A synthesized controller (e.g. an implicit batch wrapper): no `source` and
+        // no declaring header anywhere — mirrors today's silent-log behavior.
+        const graphspec = {
+            meta: { format: 'mthds' },
+            nodes: [{ pipe_code: 'process_batch', domain_code: 'rec', kind: 'controller' }],
+            edges: [],
+            pipe_registry: { 'rec.process_batch': { code: 'process_batch', domain_code: 'rec' } },
+        };
+        mockState.docContents['/project/methods/bundle.mthds'] = 'domain = "rec"\n[pipe.main]\n';
+        mockState.bundleFiles = [
+            { uri: primaryUri, name: 'bundle.mthds', content: mockState.docContents['/project/methods/bundle.mthds'] },
+        ];
+
+        const panel = new MethodGraphPanel(output, makeExtensionUri());
+        const messageHandler = await showGraphWithSpec(panel, primaryUri, graphspec);
+
+        messageHandler({ type: 'navigateToPipe', pipeCode: 'process_batch' });
+        await new Promise(r => setTimeout(r, 20));
+
+        expect(output.appendLine).toHaveBeenCalledWith(
+            expect.stringContaining('Could not find [pipe.process_batch]'),
+        );
         panel.dispose();
     });
 

--- a/editors/vscode/src/pipelex/__tests__/methodGraphPanel.test.ts
+++ b/editors/vscode/src/pipelex/__tests__/methodGraphPanel.test.ts
@@ -1348,6 +1348,29 @@ describe('MethodGraphPanel', () => {
         panel.dispose();
     });
 
+    it('onDidChangeActiveTextEditor keeps the current graph when switching bundles in the same directory', async () => {
+        const processUtils = await import('../validation/processUtils');
+
+        const panel = new MethodGraphPanel(mockOutput(), makeExtensionUri());
+        const uri = makeUri('/project/methods/bundle.mthds');
+        panel.show(uri);
+        await new Promise(r => setTimeout(r, 20));
+
+        vi.mocked(processUtils.spawnCli).mockClear();
+        const originalTitle = mockState.mockPanel.title;
+        const editorChangeHandler = mockState.onEditorChangeHandler;
+        expect(editorChangeHandler).not.toBeNull();
+
+        await editorChangeHandler!({
+            document: { languageId: 'mthds', uri: makeUri('/project/methods/helper.mthds') },
+            viewColumn: 1,
+        });
+
+        expect(processUtils.spawnCli).not.toHaveBeenCalled();
+        expect(mockState.mockPanel.title).toBe(originalTitle);
+        panel.dispose();
+    });
+
     // --- onDidChangeTextDocument: external file changes ---
 
     it('external file change triggers debounced refresh after 500ms', async () => {

--- a/editors/vscode/src/pipelex/__tests__/methodGraphPanel.test.ts
+++ b/editors/vscode/src/pipelex/__tests__/methodGraphPanel.test.ts
@@ -582,6 +582,37 @@ describe('MethodGraphPanel', () => {
         panel.dispose();
     });
 
+    it('navigateToPipe prefers a concrete sibling over a same-code signature when registry source is absent', async () => {
+        const vscode = await import('vscode');
+        const primaryUri = makeUri('/project/methods/bundle.mthds');
+        const siblingUri = makeUri('/project/methods/screen.mthds');
+
+        const graphspec = {
+            meta: { format: 'mthds' },
+            nodes: [{ pipe_code: 'screen', domain_code: 'rec', kind: 'controller' }],
+            edges: [],
+            pipe_registry: {
+                'rec.screen': { code: 'screen', domain_code: 'rec' },
+            },
+        };
+        mockState.docContents['/project/methods/screen.mthds'] =
+            'domain = "rec"\n[pipe.screen]\ntype = "PipeSequence"\n';
+        mockState.bundleFiles = [
+            { uri: primaryUri, name: 'bundle.mthds', content: 'domain = "rec"\n[pipe.screen]\ntype = "PipeSignature"\n' },
+            { uri: siblingUri, name: 'screen.mthds', content: mockState.docContents['/project/methods/screen.mthds'] },
+        ];
+
+        const panel = new MethodGraphPanel(mockOutput(), makeExtensionUri());
+        const messageHandler = await showGraphWithSpec(panel, primaryUri, graphspec);
+
+        vi.mocked(vscode.workspace.openTextDocument).mockClear();
+        messageHandler({ type: 'navigateToPipe', pipeCode: 'screen' });
+        await new Promise(r => setTimeout(r, 20));
+
+        expect(vscode.workspace.openTextDocument).toHaveBeenCalledWith(siblingUri);
+        panel.dispose();
+    });
+
     it('navigateToPipe reads domain-less registry sources from `.pipe` keys', async () => {
         const vscode = await import('vscode');
         const primaryUri = makeUri('/project/methods/bundle.mthds');

--- a/editors/vscode/src/pipelex/__tests__/pipelexValidator.test.ts
+++ b/editors/vscode/src/pipelex/__tests__/pipelexValidator.test.ts
@@ -245,4 +245,40 @@ describe('PipelexValidator — per-directory generation gate', () => {
 
         validator.dispose();
     });
+
+    it('places source-less graph-analysis diagnostics on the selected bundle primary', async () => {
+        const backend = {
+            kind: 'cli',
+            analyze: () => Promise.resolve({
+                validation: {
+                    ok: false,
+                    errors: [{ category: 'dry_run', message: 'Dry run failed' }],
+                },
+                graph: null,
+            }),
+        };
+        const factory = { getBackend: () => backend } as any;
+        const graphSink = {
+            isShowingMthds: vi.fn(() => true),
+            applyAnalysis: vi.fn(),
+            applyBackendError: vi.fn(),
+            applySkipped: vi.fn(),
+        };
+        const validator = new PipelexValidator({ appendLine: vi.fn() } as any, factory);
+        validator.setGraphSink(graphSink as any);
+
+        const helper = mkDoc('/proj/helper.mthds');
+        const bundleUri = { scheme: 'file', fsPath: '/proj/bundle.mthds', toString: () => 'file:///proj/bundle.mthds' };
+        mockState.bundleFiles = [
+            { uri: helper.uri, name: 'helper.mthds', content: 'domain = "rec"\n[pipe.helper]\n' },
+            { uri: bundleUri, name: 'bundle.mthds', content: 'domain = "rec"\nmain_pipe = "main"\n[pipe.main]\n' },
+        ];
+
+        await mockState.onSaveHandler!(helper);
+
+        expect(mockState.diagStore.get('file:///proj/bundle.mthds')).toEqual([{ message: 'Dry run failed' }]);
+        expect(mockState.diagStore.has('file:///proj/helper.mthds')).toBe(false);
+
+        validator.dispose();
+    });
 });

--- a/editors/vscode/src/pipelex/__tests__/pipelexValidator.test.ts
+++ b/editors/vscode/src/pipelex/__tests__/pipelexValidator.test.ts
@@ -8,6 +8,7 @@ const mockState = vi.hoisted(() => ({
     diagStore: new Map<string, any>(),
     setCalls: [] as string[],
     configEnabled: true,
+    bundleFiles: [] as any[],
 }));
 
 vi.mock('vscode', () => {
@@ -43,9 +44,8 @@ vi.mock('vscode', () => {
     };
 });
 
-// gatherBundleFiles is irrelevant to the generation-gating logic — stub it.
 vi.mock('../validation/bundleGather', () => ({
-    gatherBundleFiles: vi.fn(async () => []),
+    gatherBundleFiles: vi.fn(async () => mockState.bundleFiles),
 }));
 
 // Isolate the test from the real diagnostics resolver (needs vscode.Range / sourceLocator):
@@ -80,6 +80,7 @@ describe('PipelexValidator — per-directory generation gate', () => {
         mockState.diagStore.clear();
         mockState.setCalls.length = 0;
         mockState.configEnabled = true;
+        mockState.bundleFiles = [];
     });
 
     it('a stale sibling run does not clobber a newer save in the same directory', async () => {
@@ -202,6 +203,46 @@ describe('PipelexValidator — per-directory generation gate', () => {
         await p;
 
         expect(mockState.diagStore.get('file:///proj/solo.mthds')).toEqual([{ message: 'solo-error' }]);
+        validator.dispose();
+    });
+
+    it('uses the directory main bundle for save-time graph analysis of an ancillary file', async () => {
+        let capturedRequest: any;
+        let capturedOptions: any;
+        const backend = {
+            kind: 'cli',
+            analyze: (req: any, opts: any) => {
+                capturedRequest = req;
+                capturedOptions = opts;
+                return Promise.resolve({ validation: { ok: true, errors: [] }, graph: { nodes: [], edges: [] } });
+            },
+        };
+        const factory = { getBackend: () => backend } as any;
+        const graphSink = {
+            isShowingMthds: vi.fn(() => true),
+            applyAnalysis: vi.fn(),
+            applyBackendError: vi.fn(),
+            applySkipped: vi.fn(),
+        };
+        const validator = new PipelexValidator({ appendLine: vi.fn() } as any, factory);
+        validator.setGraphSink(graphSink as any);
+
+        const helper = mkDoc('/proj/helper.mthds');
+        const bundleUri = { scheme: 'file', fsPath: '/proj/bundle.mthds', toString: () => 'file:///proj/bundle.mthds' };
+        mockState.bundleFiles = [
+            { uri: helper.uri, name: 'helper.mthds', content: 'domain = "rec"\n[pipe.helper]\n' },
+            { uri: bundleUri, name: 'bundle.mthds', content: 'domain = "rec"\nmain_pipe = "main"\n[pipe.main]\n' },
+        ];
+
+        await mockState.onSaveHandler!(helper);
+
+        expect(capturedOptions.withGraph).toBe(true);
+        expect(capturedRequest.primaryUri.fsPath).toBe('/proj/bundle.mthds');
+        expect(capturedRequest.files.map((file: any) => file.name)).toEqual(['bundle.mthds', 'helper.mthds']);
+        expect(graphSink.applyAnalysis).toHaveBeenCalledWith(helper.uri, expect.objectContaining({
+            graph: { nodes: [], edges: [] },
+        }));
+
         validator.dispose();
     });
 });

--- a/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
+++ b/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
@@ -36,8 +36,8 @@ const WEBVIEW_ALLOWED_COMMANDS = new Set<string>([SET_API_KEY_COMMAND]);
  * full graphspec it forwarded to the webview and reads only these fields.
  */
 interface GraphspecForNav {
-    nodes?: Array<{ pipe_code?: string; domain_code?: string }>;
-    pipe_registry?: Record<string, { source?: string } | undefined>;
+    nodes?: Array<{ id?: string; pipe_code?: string; domain_code?: string }>;
+    pipe_registry?: Record<string, { code?: string; domain_code?: string; source?: string } | undefined>;
 }
 
 /** A clicked pipe node's resolved identity bits, recovered from the retained graphspec. */
@@ -179,6 +179,7 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
     }
 
     show(uri: vscode.Uri) {
+        this.clearNavigationState();
         this.currentUri = uri;
         this.sourceKind = 'mthds';
         const filename = uri.fsPath.replace(/^.*[\\/]/, '');
@@ -204,6 +205,7 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
     }
 
     restore(panel: vscode.WebviewPanel, uri: vscode.Uri) {
+        this.clearNavigationState();
         this.panel = panel;
         this.currentUri = uri;
         this.sourceKind = 'mthds';
@@ -222,6 +224,7 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
     }
 
     showGraphspecJson(uri: vscode.Uri) {
+        this.clearNavigationState();
         this.currentUri = uri;
         this.sourceKind = 'graphspec-json';
         const filename = uri.fsPath.replace(/^.*[\\/]/, '');
@@ -247,6 +250,7 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
     }
 
     restoreGraphspecJson(panel: vscode.WebviewPanel, uri: vscode.Uri) {
+        this.clearNavigationState();
         this.panel = panel;
         this.currentUri = uri;
         this.sourceKind = 'graphspec-json';
@@ -274,7 +278,7 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
             this.currentUri = undefined;
             this.sourceKind = undefined;
             this.webviewReady = false;
-            this.currentGraphspec = undefined;
+            this.clearNavigationState();
         });
         this.panel.webview.onDidReceiveMessage(
             message => this.handleWebviewMessage(message),
@@ -391,6 +395,7 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
             return;
         }
 
+        this.clearNavigationState();
         this.setHtml(messageHtml('No Graph Available', 'The bundle did not produce a method graph.'));
     }
 
@@ -401,6 +406,7 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
      * {@link errorTargets} for index-based navigation.
      */
     private async renderValidationErrors(uri: vscode.Uri, errors: ValidationErrorItem[]): Promise<void> {
+        this.clearNavigationState();
         // The CLI path resolves siblings itself, so `refresh()` does not gather them;
         // the clickable list needs their contents to place an error on its owning file.
         // A gather failure (transient read error, deleted primary file) must NOT reject:
@@ -459,10 +465,12 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
     applySkipped(uri: vscode.Uri, message: string): void {
         if (!this.panel) return;
         if (this.currentUri?.toString() !== uri.toString()) return;
+        this.clearNavigationState();
         this.setHtml(messageHtml('Graph Unavailable', escapeHtml(message)));
     }
 
     private renderBackendError(err: unknown): void {
+        this.clearNavigationState();
         if (err instanceof BackendError) {
             switch (err.kind) {
                 case 'not-found':
@@ -549,21 +557,24 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
             try {
                 content = await fs.promises.readFile(uri.fsPath, 'utf-8');
             } catch (err: any) {
+                if (this.currentUri?.toString() !== uri.toString()) return;
+                this.clearNavigationState();
                 this.setHtml(messageHtml('Read Error', `Could not read file: ${escapeHtml(err.message ?? String(err))}`, { retry: true }));
                 return;
             }
         }
 
+        if (this.currentUri?.toString() !== uri.toString()) return;
+
         const graphspec = parseGraphspecFile(content);
         if (!graphspec) {
+            this.clearNavigationState();
             this.setHtml(messageHtml(
                 'Invalid GraphSpec',
                 'File does not contain a valid MTHDS GraphSpec JSON (missing <code>meta.format</code>, <code>nodes</code>, or <code>edges</code>).'
             ));
             return;
         }
-
-        if (this.currentUri?.toString() !== uri.toString()) return;
 
         const pipelexConfig = vscode.workspace.getConfiguration('pipelex');
         const direction = pipelexConfig.get<string>('graph.direction', 'top_down');
@@ -600,6 +611,7 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
         // Retain the graphspec so a pipe-node click can recover its declaring
         // domain + registry `source` (see navigateToPipe). Set alongside the send
         // so it always matches what the webview is rendering.
+        this.errorTargets = [];
         this.currentGraphspec = graphspec;
 
         const setDataPayload = {
@@ -635,6 +647,11 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
             this.pendingData = setDataPayload;
             this.setHtml(webviewHtml);
         }
+    }
+
+    private clearNavigationState(): void {
+        this.currentGraphspec = undefined;
+        this.errorTargets = [];
     }
 
     private buildWebviewHtml(): string | undefined {
@@ -757,7 +774,9 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
         }
         if (message.type === 'navigateToPipe' && message.pipeCode && this.currentUri) {
             if (this.sourceKind === 'graphspec-json') return;
-            this.navigateToPipe(message.pipeCode);
+            const domainCode = typeof message.domainCode === 'string' ? message.domainCode : undefined;
+            const nodeId = typeof message.nodeId === 'string' ? message.nodeId : undefined;
+            this.navigateToPipe(message.pipeCode, domainCode, nodeId);
             return;
         }
         if (message.type === 'navigateToError' && typeof message.index === 'number' && this.currentUri) {
@@ -796,22 +815,44 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
 
     /**
      * Recover a clicked pipe node's identity from the retained graphspec. The
-     * webview message carries only the bare `pipeCode`, so the node is matched by
-     * `pipe_code` to recover its `domain_code`, which keys into `pipe_registry`
-     * for the declaration `source` path.
-     *
-     * v1 edge: if the same `pipe_code` appears under two domains as two nodes, a
-     * bare `pipeCode` can't say which was clicked — the first node match wins, and
-     * the scan fallback still finds a correct declaration. The bulletproof upgrade
-     * (wiring mthds-ui's `onNodeSelect(nodeId, nodeData)`) is recorded but not done
-     * here, to keep the webview message contract unchanged.
+     * webview normally sends the clicked node id/domain recovered through
+     * GraphViewer's `onNodeSelect`; older renderers/messages may still send only
+     * the bare `pipeCode`. Prefer exact node/domain matching, then fall back to a
+     * unique bare-code match. Registry keys are tried with both `domain.code` and
+     * `.code` because domain-less pipes are serialized with an empty-domain key.
      */
-    private lookupPipeNode(pipeCode: string): PipeNodeIdentity {
+    private lookupPipeNode(pipeCode: string, clickedDomainCode?: string, clickedNodeId?: string): PipeNodeIdentity {
         const spec = this.currentGraphspec as GraphspecForNav | undefined;
-        const node = spec?.nodes?.find(n => n.pipe_code === pipeCode);
-        const domainCode = node?.domain_code;
-        const source = domainCode ? spec?.pipe_registry?.[`${domainCode}.${pipeCode}`]?.source : undefined;
+        const candidates = spec?.nodes?.filter(n => n.pipe_code === pipeCode) ?? [];
+        const node =
+            (clickedNodeId ? candidates.find(n => n.id === clickedNodeId) : undefined)
+            ?? (clickedDomainCode !== undefined ? candidates.find(n => (n.domain_code ?? '') === clickedDomainCode) : undefined)
+            ?? (candidates.length === 1 ? candidates[0] : undefined);
+        const domainCode = clickedDomainCode ?? node?.domain_code;
+        const source = this.lookupPipeRegistrySource(pipeCode, domainCode);
         return { domainCode, source };
+    }
+
+    private lookupPipeRegistrySource(pipeCode: string, domainCode?: string): string | undefined {
+        const registry = (this.currentGraphspec as GraphspecForNav | undefined)?.pipe_registry;
+        if (!registry) return undefined;
+
+        const keys = domainCode
+            ? [`${domainCode}.${pipeCode}`]
+            : [`.${pipeCode}`];
+        for (const key of keys) {
+            const source = registry[key]?.source;
+            if (source) return source;
+        }
+
+        const matches = Object.entries(registry).filter(([key, value]) => {
+            const registryCode = value?.code ?? key.substring(key.lastIndexOf('.') + 1);
+            if (registryCode !== pipeCode) return false;
+            if (domainCode === undefined) return true;
+            const registryDomain = value?.domain_code ?? key.substring(0, key.length - pipeCode.length - 1);
+            return registryDomain === domainCode;
+        });
+        return matches.length === 1 ? matches[0][1]?.source : undefined;
     }
 
     /**
@@ -826,12 +867,13 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
      * the exact line still comes from scanning the opened document, so the live
      * (possibly unsaved) buffer of the primary is honored.
      */
-    private async navigateToPipe(pipeCode: string) {
+    private async navigateToPipe(pipeCode: string, clickedDomainCode?: string, clickedNodeId?: string) {
         const primaryUri = this.currentUri;
         if (!primaryUri) return;
+        const primaryUriString = primaryUri.toString();
 
         try {
-            const { domainCode, source } = this.lookupPipeNode(pipeCode);
+            const { domainCode, source } = this.lookupPipeNode(pipeCode, clickedDomainCode, clickedNodeId);
 
             // The CLI path doesn't gather siblings during refresh (it reads them via
             // --library-dir), so gather them here to resolve a cross-file declaration.
@@ -842,6 +884,19 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
             } catch {
                 files = [];
             }
+            if (!this.panel || this.currentUri?.toString() !== primaryUriString) return;
+
+            const linesCache = new Map<string, string[]>();
+            const getLines = (file: BundleFile): string[] => {
+                const key = file.uri.toString();
+                let lines = linesCache.get(key);
+                if (!lines) {
+                    const openDoc = vscode.workspace.textDocuments.find(d => d.uri.toString() === key);
+                    lines = openDoc ? textDocumentLines(openDoc) : file.content.split(/\r\n|\r|\n/);
+                    linesCache.set(key, lines);
+                }
+                return lines;
+            };
 
             const owner = resolveDeclaringFile({
                 kind: 'pipe',
@@ -849,11 +904,12 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
                 domainCode,
                 source,
                 files,
-                getLines: f => f.content.split(/\r\n|\r|\n/),
+                getLines,
             });
             const targetUri = owner?.uri ?? primaryUri;
 
             const document = await vscode.workspace.openTextDocument(targetUri);
+            if (!this.panel || this.currentUri?.toString() !== primaryUriString) return;
             const headerLine = findTableHeader(document, 'pipe', pipeCode);
             if (headerLine === -1) {
                 this.output.appendLine(`Could not find [pipe.${pipeCode}] in ${targetUri.fsPath}`);
@@ -1057,6 +1113,14 @@ function basename(fsPath: string): string {
     return fsPath.replace(/^.*[\\/]/, '');
 }
 
+function textDocumentLines(document: vscode.TextDocument): string[] {
+    const lines: string[] = [];
+    for (let i = 0; i < document.lineCount; i++) {
+        lines.push(document.lineAt(i).text);
+    }
+    return lines;
+}
+
 /**
  * Render the validation errors as a clickable list. Each row posts
  * `{ type: 'navigateToError', index }` (never a path) so the extension can open
@@ -1128,4 +1192,3 @@ ${items}
 </script>
 </div></body></html>`;
 }
-

--- a/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
+++ b/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
@@ -142,15 +142,24 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
 
                 if (editor.document.languageId === 'mthds' && editor.document.uri.scheme === 'file') {
                     const newUri = editor.document.uri;
-                    if (
-                        !this.currentUri ||
-                        (
-                            newUri.toString() !== this.currentUri.toString() &&
-                            !sameDirectory(newUri, this.currentUri)
-                        )
-                    ) {
+                    const currentUri = this.currentUri;
+                    if (!currentUri || this.sourceKind !== 'mthds') {
                         this.show(newUri);
+                        return;
                     }
+                    if (newUri.toString() === currentUri.toString()) {
+                        return;
+                    }
+                    if (sameDirectory(newUri, currentUri)) {
+                        const samePrimary = await resolvesToSameGraphPrimary(newUri, currentUri);
+                        if (this.currentUri?.toString() !== currentUri.toString() || this.sourceKind !== 'mthds') {
+                            return;
+                        }
+                        if (samePrimary) {
+                            return;
+                        }
+                    }
+                    this.show(newUri);
                 } else if (editor.document.languageId === 'json' && editor.document.uri.scheme === 'file') {
                     const graphspec = parseGraphspecFile(editor.document.getText());
                     if (graphspec) {
@@ -1123,6 +1132,18 @@ function basename(fsPath: string): string {
 
 function sameDirectory(a: vscode.Uri, b: vscode.Uri): boolean {
     return dirname(a.fsPath) === dirname(b.fsPath);
+}
+
+async function resolvesToSameGraphPrimary(a: vscode.Uri, b: vscode.Uri): Promise<boolean> {
+    try {
+        const [aPrimary, bPrimary] = await Promise.all([
+            resolveGraphPrimaryBundle(a),
+            resolveGraphPrimaryBundle(b),
+        ]);
+        return aPrimary.primaryUri.toString() === bPrimary.primaryUri.toString();
+    } catch {
+        return false;
+    }
 }
 
 function dirname(fsPath: string): string {

--- a/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
+++ b/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
@@ -142,7 +142,13 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
 
                 if (editor.document.languageId === 'mthds' && editor.document.uri.scheme === 'file') {
                     const newUri = editor.document.uri;
-                    if (!this.currentUri || newUri.toString() !== this.currentUri.toString()) {
+                    if (
+                        !this.currentUri ||
+                        (
+                            newUri.toString() !== this.currentUri.toString() &&
+                            !sameDirectory(newUri, this.currentUri)
+                        )
+                    ) {
                         this.show(newUri);
                     }
                 } else if (editor.document.languageId === 'json' && editor.document.uri.scheme === 'file') {
@@ -1113,6 +1119,16 @@ function errorContext(error: ValidationErrorItem): string | undefined {
 /** Last path segment of a file path, cross-platform (handles `/` and `\`). */
 function basename(fsPath: string): string {
     return fsPath.replace(/^.*[\\/]/, '');
+}
+
+function sameDirectory(a: vscode.Uri, b: vscode.Uri): boolean {
+    return dirname(a.fsPath) === dirname(b.fsPath);
+}
+
+function dirname(fsPath: string): string {
+    const normalized = fsPath.replace(/\\/g, '/');
+    const index = normalized.lastIndexOf('/');
+    return index === -1 ? '' : normalized.slice(0, index);
 }
 
 function textDocumentLines(document: vscode.TextDocument): string[] {

--- a/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
+++ b/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
@@ -4,8 +4,9 @@ import * as fs from 'fs';
 import { cancelAllInflight } from '../validation/processUtils';
 import { gatherBundleFiles } from '../validation/bundleGather';
 import { resolveErrorLocations } from '../validation/crossFileDiagnostics';
+import { resolveDeclaringFile } from '../validation/bundleResolution';
 import { AnalyzeAbortError, BackendError } from '../validation/backend';
-import type { BackendErrorAction, BundleAnalysis, GraphAnalysisSink, ValidationBackend } from '../validation/backend';
+import type { BackendErrorAction, BundleAnalysis, BundleFile, GraphAnalysisSink, ValidationBackend } from '../validation/backend';
 import { CliValidationBackend } from '../validation/cliValidationBackend';
 import { SET_API_KEY_COMMAND } from '../validation/apiKey';
 import { findTableHeader } from '../validation/sourceLocator';
@@ -26,6 +27,26 @@ const RETRY_NONCE_SENTINEL = 'PIPELEX_RETRY_NONCE';
 
 /** Commands the message-view buttons may dispatch — a closed allowlist, not arbitrary command execution. */
 const WEBVIEW_ALLOWED_COMMANDS = new Set<string>([SET_API_KEY_COMMAND]);
+
+/**
+ * The subset of a GraphSpec the panel reads to map a clicked pipe node back to
+ * its declaring file. Loosely typed on purpose: the registry's `source` field is
+ * an additive, feature-detected enrichment (older CLIs omit it) and is not part
+ * of the published `@pipelex/mthds-ui` GraphSpec types. The panel retains the
+ * full graphspec it forwarded to the webview and reads only these fields.
+ */
+interface GraphspecForNav {
+    nodes?: Array<{ pipe_code?: string; domain_code?: string }>;
+    pipe_registry?: Record<string, { source?: string } | undefined>;
+}
+
+/** A clicked pipe node's resolved identity bits, recovered from the retained graphspec. */
+interface PipeNodeIdentity {
+    /** The node's declaring domain, when the graphspec carries it. */
+    domainCode?: string;
+    /** The declaring file path from `pipe_registry[domain.code].source`, when present. */
+    source?: string;
+}
 
 export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
     private static readonly CSP_NONCE_SENTINEL = 'PIPELEX_CSP_NONCE';
@@ -48,6 +69,13 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
      * so it can never request an arbitrary file — see {@link navigateToError}.
      */
     private errorTargets: { uri: vscode.Uri; range: vscode.Range }[] = [];
+    /**
+     * The graphspec last forwarded to the webview, retained so a `navigateToPipe`
+     * click can recover the clicked node's `domain_code` and registry `source`
+     * (the webview message carries only the bare `pipeCode`). Reset on every send,
+     * cleared on dispose.
+     */
+    private currentGraphspec: unknown;
 
     constructor(
         output: vscode.OutputChannel,
@@ -246,6 +274,7 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
             this.currentUri = undefined;
             this.sourceKind = undefined;
             this.webviewReady = false;
+            this.currentGraphspec = undefined;
         });
         this.panel.webview.onDidReceiveMessage(
             message => this.handleWebviewMessage(message),
@@ -568,6 +597,11 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
 
         if (this.currentUri?.toString() !== uri.toString()) return;
 
+        // Retain the graphspec so a pipe-node click can recover its declaring
+        // domain + registry `source` (see navigateToPipe). Set alongside the send
+        // so it always matches what the webview is rendering.
+        this.currentGraphspec = graphspec;
+
         const setDataPayload = {
             type: 'setData',
             uri: uri.toString(),
@@ -760,28 +794,73 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
         }
     }
 
+    /**
+     * Recover a clicked pipe node's identity from the retained graphspec. The
+     * webview message carries only the bare `pipeCode`, so the node is matched by
+     * `pipe_code` to recover its `domain_code`, which keys into `pipe_registry`
+     * for the declaration `source` path.
+     *
+     * v1 edge: if the same `pipe_code` appears under two domains as two nodes, a
+     * bare `pipeCode` can't say which was clicked — the first node match wins, and
+     * the scan fallback still finds a correct declaration. The bulletproof upgrade
+     * (wiring mthds-ui's `onNodeSelect(nodeId, nodeData)`) is recorded but not done
+     * here, to keep the webview message contract unchanged.
+     */
+    private lookupPipeNode(pipeCode: string): PipeNodeIdentity {
+        const spec = this.currentGraphspec as GraphspecForNav | undefined;
+        const node = spec?.nodes?.find(n => n.pipe_code === pipeCode);
+        const domainCode = node?.domain_code;
+        const source = domainCode ? spec?.pipe_registry?.[`${domainCode}.${pipeCode}`]?.source : undefined;
+        return { domainCode, source };
+    }
+
+    /**
+     * Reveal the code for a clicked pipe node, across files in the bundle.
+     *
+     * Resolution is source-first, scan-as-fallback (feature-detected, no version
+     * floor): the registry `source` gives an exact declaring file when present
+     * (so a signature/concrete split lands on the concrete implementation in a
+     * sibling), else the gathered siblings are scanned for the `[pipe.<code>]`
+     * declaration. When neither resolves a sibling, it falls back to the primary
+     * file — today's single-file behavior. The owning file is resolved to a URI;
+     * the exact line still comes from scanning the opened document, so the live
+     * (possibly unsaved) buffer of the primary is honored.
+     */
     private async navigateToPipe(pipeCode: string) {
-        if (!this.currentUri) return;
+        const primaryUri = this.currentUri;
+        if (!primaryUri) return;
 
         try {
-            const document = await vscode.workspace.openTextDocument(this.currentUri);
+            const { domainCode, source } = this.lookupPipeNode(pipeCode);
+
+            // The CLI path doesn't gather siblings during refresh (it reads them via
+            // --library-dir), so gather them here to resolve a cross-file declaration.
+            // A gather failure degrades to the primary-only path rather than aborting.
+            let files: BundleFile[];
+            try {
+                files = await gatherBundleFiles(primaryUri);
+            } catch {
+                files = [];
+            }
+
+            const owner = resolveDeclaringFile({
+                kind: 'pipe',
+                code: pipeCode,
+                domainCode,
+                source,
+                files,
+                getLines: f => f.content.split(/\r\n|\r|\n/),
+            });
+            const targetUri = owner?.uri ?? primaryUri;
+
+            const document = await vscode.workspace.openTextDocument(targetUri);
             const headerLine = findTableHeader(document, 'pipe', pipeCode);
             if (headerLine === -1) {
-                this.output.appendLine(`Could not find [pipe.${pipeCode}] in ${this.currentUri.fsPath}`);
+                this.output.appendLine(`Could not find [pipe.${pipeCode}] in ${targetUri.fsPath}`);
                 return;
             }
 
-            const panelCol = this.panel?.viewColumn;
-            const targetCol = panelCol && panelCol > 1 ? panelCol - 1 : vscode.ViewColumn.One;
-
-            const editor = await vscode.window.showTextDocument(document, {
-                viewColumn: targetCol,
-                preserveFocus: false,
-            });
-
-            const range = document.lineAt(headerLine).range;
-            editor.selection = new vscode.Selection(range.start, range.end);
-            editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+            await this.revealRangeBeside(document, document.lineAt(headerLine).range);
         } catch (err: any) {
             this.output.appendLine(`navigateToPipe error: ${err.message ?? err}`);
         }
@@ -799,20 +878,29 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
 
         try {
             const document = await vscode.workspace.openTextDocument(target.uri);
-
-            const panelCol = this.panel?.viewColumn;
-            const targetCol = panelCol && panelCol > 1 ? panelCol - 1 : vscode.ViewColumn.One;
-
-            const editor = await vscode.window.showTextDocument(document, {
-                viewColumn: targetCol,
-                preserveFocus: false,
-            });
-
-            editor.selection = new vscode.Selection(target.range.start, target.range.end);
-            editor.revealRange(target.range, vscode.TextEditorRevealType.InCenter);
+            await this.revealRangeBeside(document, target.range);
         } catch (err: any) {
             this.output.appendLine(`navigateToError error: ${err.message ?? err}`);
         }
+    }
+
+    /**
+     * Open `document` in the column beside the panel and reveal `range`, centered
+     * and selected. Shared by pipe-node navigation and error-list navigation so
+     * both place the cursor identically. The target column is one left of the
+     * panel (or column 1 when the panel is already leftmost).
+     */
+    private async revealRangeBeside(document: vscode.TextDocument, range: vscode.Range): Promise<void> {
+        const panelCol = this.panel?.viewColumn;
+        const targetCol = panelCol && panelCol > 1 ? panelCol - 1 : vscode.ViewColumn.One;
+
+        const editor = await vscode.window.showTextDocument(document, {
+            viewColumn: targetCol,
+            preserveFocus: false,
+        });
+
+        editor.selection = new vscode.Selection(range.start, range.end);
+        editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
     }
 
     private setHtml(html: string) {

--- a/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
+++ b/editors/vscode/src/pipelex/graph/methodGraphPanel.ts
@@ -3,6 +3,7 @@ import * as crypto from 'crypto';
 import * as fs from 'fs';
 import { cancelAllInflight } from '../validation/processUtils';
 import { gatherBundleFiles } from '../validation/bundleGather';
+import { resolveGraphPrimaryBundle } from '../validation/graphPrimary';
 import { resolveErrorLocations } from '../validation/crossFileDiagnostics';
 import { resolveDeclaringFile } from '../validation/bundleResolution';
 import { AnalyzeAbortError, BackendError } from '../validation/backend';
@@ -335,10 +336,11 @@ export class MethodGraphPanel implements vscode.Disposable, GraphAnalysisSink {
 
         try {
             const backend = this.getBackend(uri);
+            const graphPrimary = await resolveGraphPrimaryBundle(uri);
             // The CLI reads siblings via `--library-dir` itself; only the API path needs contents.
-            const files = backend.kind === 'api' ? await gatherBundleFiles(uri) : [];
+            const files = backend.kind === 'api' ? graphPrimary.files : [];
             const analysis = await backend.analyze(
-                { primaryUri: uri, files, cwd: workspaceFolder?.uri.fsPath, timeout },
+                { primaryUri: graphPrimary.primaryUri, files, cwd: workspaceFolder?.uri.fsPath, timeout },
                 { withGraph: true, direction },
                 controller.signal,
             );

--- a/editors/vscode/src/pipelex/graph/webview/adapter.ts
+++ b/editors/vscode/src/pipelex/graph/webview/adapter.ts
@@ -40,10 +40,36 @@ let lastReportedMode: GraphThemeMode | undefined;
 // Held so we can preserve the viewport across same-file refreshes.
 let reactFlowInstance: any = null;
 
+let lastSelectedPipeNode: { nodeId: string; pipeCode?: string; domainCode?: string } | null = null;
+
 // --- Callbacks passed to GraphViewer ---
 
 function onNavigateToPipe(pipeCode: string) {
-    vscode.postMessage({ type: 'navigateToPipe', pipeCode });
+    const selected = lastSelectedPipeNode?.pipeCode === pipeCode ? lastSelectedPipeNode : null;
+    vscode.postMessage({
+        type: 'navigateToPipe',
+        pipeCode,
+        nodeId: selected?.nodeId,
+        domainCode: selected?.domainCode,
+    });
+}
+
+function onNodeSelect(nodeId: string, nodeData: any) {
+    const pipeCode = typeof nodeData?.pipeCode === 'string'
+        ? nodeData.pipeCode
+        : typeof nodeData?.labelText === 'string'
+            ? nodeData.labelText
+            : undefined;
+    if (!pipeCode) {
+        lastSelectedPipeNode = null;
+        return;
+    }
+    const specNode = currentGraphspec?.nodes?.find(n => n.id === nodeId && n.pipe_code === pipeCode);
+    lastSelectedPipeNode = {
+        nodeId,
+        pipeCode,
+        domainCode: specNode?.domain_code,
+    };
 }
 
 function onReactFlowInit(instance: any) {
@@ -103,6 +129,7 @@ function handleMessage(event: { data: any }) {
         }
 
         currentUri = message.uri || null;
+        lastSelectedPipeNode = null;
 
         currentGraphspec = message.graphspec || null;
         currentConfig = message.config || {};
@@ -166,6 +193,7 @@ function App() {
         // survives panel reloads and VS Code restarts.
         onThemeChange,
         onNavigateToPipe,
+        onNodeSelect,
         onReactFlowInit,
         canEmbedPdf: false,
         onOpenExternally,

--- a/editors/vscode/src/pipelex/validation/bundleResolution.ts
+++ b/editors/vscode/src/pipelex/validation/bundleResolution.ts
@@ -1,5 +1,5 @@
 import type { BundleFile } from './backend';
-import { findTableHeaderInLines } from './sourceLocator';
+import { escapeRegex, findTableHeaderInLines } from './sourceLocator';
 
 /** A declaration kind addressable by a `[<kind>.<code>]` table header. */
 export type DeclarationKind = 'pipe' | 'concept';
@@ -32,7 +32,7 @@ export function resolveDeclaringFile(args: {
 
     if (source) {
         const match = matchSourceFile(source, files);
-        if (match) {
+        if (match && findTableHeaderInLines(getLines(match), kind, code) !== -1) {
             return match;
         }
     }
@@ -56,7 +56,7 @@ export function matchSourceFile(source: string, files: BundleFile[]): BundleFile
     const src = source.replace(/\\/g, '/');
     const srcBase = src.substring(src.lastIndexOf('/') + 1);
     const isBareName = src === srcBase;
-    return files.find(f => {
+    const matches = files.filter(f => {
         const fsPath = f.uri.fsPath.replace(/\\/g, '/');
         const fsBase = fsPath.substring(fsPath.lastIndexOf('/') + 1);
         const name = f.name.replace(/\\/g, '/');
@@ -67,6 +67,10 @@ export function matchSourceFile(source: string, files: BundleFile[]): BundleFile
             fsPath.endsWith('/' + src)
         );
     });
+    if (isBareName && matches.length > 1) {
+        return undefined;
+    }
+    return matches[0];
 }
 
 /**
@@ -92,7 +96,7 @@ export function findDeclaringFileByScan(
 
 /** Whether a file's lines declare a top-level `domain = "<domainCode>"`. */
 function fileDeclaresDomain(lines: string[], domainCode: string): boolean {
-    const pattern = new RegExp(`^\\s*domain\\s*=\\s*["']${escapeRegex(domainCode)}["']`);
+    const pattern = new RegExp(`^\\s*domain\\s*=\\s*(["'])${escapeRegex(domainCode)}\\1\\s*(?:#.*)?$`);
     for (const line of lines) {
         if (pattern.test(line)) {
             return true;
@@ -104,8 +108,4 @@ function fileDeclaresDomain(lines: string[], domainCode: string): boolean {
         }
     }
     return false;
-}
-
-function escapeRegex(s: string): string {
-    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/editors/vscode/src/pipelex/validation/bundleResolution.ts
+++ b/editors/vscode/src/pipelex/validation/bundleResolution.ts
@@ -33,6 +33,18 @@ export function resolveDeclaringFile(args: {
     if (source) {
         const match = matchSourceFile(source, files);
         if (match && findTableHeaderInLines(getLines(match), kind, code) !== -1) {
+            if (kind === 'pipe' && pipeDeclarationIsSignature(getLines(match), code)) {
+                const concrete = findDeclaringFileByScan(
+                    kind,
+                    code,
+                    files,
+                    domainCode ?? fileDeclaredDomain(getLines(match)),
+                    getLines,
+                );
+                if (concrete && !pipeDeclarationIsSignature(getLines(concrete), code)) {
+                    return concrete;
+                }
+            }
             return match;
         }
     }
@@ -74,11 +86,11 @@ export function matchSourceFile(source: string, files: BundleFile[]): BundleFile
 }
 
 /**
- * Find the gathered file that declares `[kind.code]`. When the same header
- * appears in more than one file (a signature/concrete split, or a same-named
- * declaration in two domains) and `domainCode` is known, prefer the file whose
- * top-level `domain = "<domainCode>"` matches; otherwise the first match wins
- * (gather order: primary first, then siblings sorted by name).
+ * Find the gathered file that declares `[kind.code]`. When the same pipe header
+ * appears in more than one file, prefer a concrete pipe over a `PipeSignature`
+ * stub so click-to-code lands on the implementation. If `domainCode` is known,
+ * apply that preference within the matching domain. Otherwise the first match
+ * wins (gather order: primary first, then siblings sorted by name).
  */
 export function findDeclaringFileByScan(
     kind: DeclarationKind,
@@ -88,23 +100,53 @@ export function findDeclaringFileByScan(
     getLines: (file: BundleFile) => string[],
 ): BundleFile | undefined {
     const matches = files.filter(f => findTableHeaderInLines(getLines(f), kind, code) !== -1);
-    if (matches.length <= 1 || !domainCode) {
+    if (matches.length <= 1) {
         return matches[0];
     }
-    return matches.find(f => fileDeclaresDomain(getLines(f), domainCode)) ?? matches[0];
+    const domainMatches = domainCode
+        ? matches.filter(f => fileDeclaresDomain(getLines(f), domainCode))
+        : [];
+    const preferredMatches = domainMatches.length > 0 ? domainMatches : matches;
+    if (kind === 'pipe') {
+        return preferredMatches.find(f => !pipeDeclarationIsSignature(getLines(f), code))
+            ?? preferredMatches[0];
+    }
+    return preferredMatches[0];
 }
 
 /** Whether a file's lines declare a top-level `domain = "<domainCode>"`. */
 function fileDeclaresDomain(lines: string[], domainCode: string): boolean {
-    const pattern = new RegExp(`^\\s*domain\\s*=\\s*(["'])${escapeRegex(domainCode)}\\1\\s*(?:#.*)?$`);
+    return fileDeclaredDomain(lines) === domainCode;
+}
+
+function fileDeclaredDomain(lines: string[]): string | undefined {
     for (const line of lines) {
-        if (pattern.test(line)) {
-            return true;
+        const match = /^\s*domain\s*=\s*(["'])(.*?)\1\s*(?:#.*)?$/.exec(line);
+        if (match) {
+            return match[2];
         }
         // A `domain` key is a top-level bundle field; stop at the first table so a
         // later `domain = ` inside a `[concept.X.structure]` field can't false-match.
         if (/^\s*\[/.test(line)) {
             break;
+        }
+    }
+    return undefined;
+}
+
+/** Whether a `[pipe.<code>]` section is a signature-only declaration. */
+function pipeDeclarationIsSignature(lines: string[], code: string): boolean {
+    const headerLine = findTableHeaderInLines(lines, 'pipe', code);
+    if (headerLine === -1) {
+        return false;
+    }
+    for (let i = headerLine + 1; i < lines.length; i++) {
+        const text = lines[i];
+        if (/^\s*\[/.test(text)) {
+            break;
+        }
+        if (/^\s*type\s*=\s*(["'])PipeSignature\1\s*(?:#.*)?$/.test(text)) {
+            return true;
         }
     }
     return false;

--- a/editors/vscode/src/pipelex/validation/bundleResolution.ts
+++ b/editors/vscode/src/pipelex/validation/bundleResolution.ts
@@ -1,0 +1,111 @@
+import type { BundleFile } from './backend';
+import { findTableHeaderInLines } from './sourceLocator';
+
+/** A declaration kind addressable by a `[<kind>.<code>]` table header. */
+export type DeclarationKind = 'pipe' | 'concept';
+
+/**
+ * Single source of truth for "which gathered file declares this pipe/concept".
+ *
+ * Both the cross-file diagnostics path ({@link resolveOwner} in
+ * `crossFileDiagnostics.ts`) and the method-graph pipe-node navigation path build
+ * on the primitives here, so they can never drift on HOW a `source` path is
+ * matched or HOW a declaration header is located.
+ *
+ * Resolution is two-tier, mirroring the source-first / scan-fallback design:
+ * 1. {@link matchSourceFile} — an exact owner from the backend-reported `source`
+ *    path (the populated-whenever-possible path; keys on the declaring file, so a
+ *    signature/concrete split resolves to the *winning* concrete declaration).
+ * 2. {@link findDeclaringFileByScan} — scan the gathered files for the one that
+ *    declares `[kind.code]`, preferring the file whose `domain` matches when the
+ *    code collides across files.
+ */
+export function resolveDeclaringFile(args: {
+    kind: DeclarationKind;
+    code: string;
+    domainCode?: string;
+    source?: string;
+    files: BundleFile[];
+    getLines: (file: BundleFile) => string[];
+}): BundleFile | undefined {
+    const { kind, code, domainCode, source, files, getLines } = args;
+
+    if (source) {
+        const match = matchSourceFile(source, files);
+        if (match) {
+            return match;
+        }
+    }
+
+    return findDeclaringFileByScan(kind, code, files, domainCode, getLines);
+}
+
+/**
+ * Match a backend-reported `source` path against the gathered files.
+ *
+ * The backend can report a POSIX-style relative source (e.g. `subdir/a.mthds`)
+ * even on Windows, where `fsPath` uses `\`. Both sides are normalized to forward
+ * slashes before matching, so a path-qualified source is not misrouted by a
+ * separator mismatch. A bare filename matches by basename; a path-qualified
+ * source must match exactly or on a path-segment boundary, so it can't misroute
+ * onto a similarly-named sibling. Tolerates absolute and relative `source`
+ * values alike (the local CLI emits absolute paths; the API emits per-content
+ * names).
+ */
+export function matchSourceFile(source: string, files: BundleFile[]): BundleFile | undefined {
+    const src = source.replace(/\\/g, '/');
+    const srcBase = src.substring(src.lastIndexOf('/') + 1);
+    const isBareName = src === srcBase;
+    return files.find(f => {
+        const fsPath = f.uri.fsPath.replace(/\\/g, '/');
+        const fsBase = fsPath.substring(fsPath.lastIndexOf('/') + 1);
+        const name = f.name.replace(/\\/g, '/');
+        return (
+            name === src ||
+            fsPath === src ||
+            (isBareName && fsBase === srcBase) ||
+            fsPath.endsWith('/' + src)
+        );
+    });
+}
+
+/**
+ * Find the gathered file that declares `[kind.code]`. When the same header
+ * appears in more than one file (a signature/concrete split, or a same-named
+ * declaration in two domains) and `domainCode` is known, prefer the file whose
+ * top-level `domain = "<domainCode>"` matches; otherwise the first match wins
+ * (gather order: primary first, then siblings sorted by name).
+ */
+export function findDeclaringFileByScan(
+    kind: DeclarationKind,
+    code: string,
+    files: BundleFile[],
+    domainCode: string | undefined,
+    getLines: (file: BundleFile) => string[],
+): BundleFile | undefined {
+    const matches = files.filter(f => findTableHeaderInLines(getLines(f), kind, code) !== -1);
+    if (matches.length <= 1 || !domainCode) {
+        return matches[0];
+    }
+    return matches.find(f => fileDeclaresDomain(getLines(f), domainCode)) ?? matches[0];
+}
+
+/** Whether a file's lines declare a top-level `domain = "<domainCode>"`. */
+function fileDeclaresDomain(lines: string[], domainCode: string): boolean {
+    const pattern = new RegExp(`^\\s*domain\\s*=\\s*["']${escapeRegex(domainCode)}["']`);
+    for (const line of lines) {
+        if (pattern.test(line)) {
+            return true;
+        }
+        // A `domain` key is a top-level bundle field; stop at the first table so a
+        // later `domain = ` inside a `[concept.X.structure]` field can't false-match.
+        if (/^\s*\[/.test(line)) {
+            break;
+        }
+    }
+    return false;
+}
+
+function escapeRegex(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/editors/vscode/src/pipelex/validation/crossFileDiagnostics.ts
+++ b/editors/vscode/src/pipelex/validation/crossFileDiagnostics.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
 import type { BundleFile } from './backend';
 import type { ValidationErrorItem } from './types';
-import { locateError, locateErrorInLines, findTableHeaderInLines } from './sourceLocator';
+import { locateError, locateErrorInLines } from './sourceLocator';
+import { matchSourceFile, findDeclaringFileByScan } from './bundleResolution';
 
 /** Diagnostics computed for one file in the bundle. */
 export interface FileDiagnostics {
@@ -105,41 +106,33 @@ export function buildBundleDiagnostics(args: {
     return [...byUri.values()];
 }
 
+/**
+ * Resolve a validation error to its owning file, in priority order:
+ * `error.source` → `pipe_code` declaration → `concept_code` declaration.
+ *
+ * The matching primitives are shared with the method-graph pipe-node navigation
+ * path ({@link resolveDeclaringFile}) so the two surfaces can never disagree on
+ * how a source path is matched or how a declaration header is found. The error
+ * path keeps its own source→pipe→concept ordering (an error may carry both a
+ * `pipe_code` and a `concept_code`); the navigation path resolves a single kind.
+ */
 function resolveOwner(
     error: ValidationErrorItem,
     files: BundleFile[],
     getLines: (file: BundleFile) => string[],
 ): BundleFile | undefined {
     if (error.source) {
-        // The backend can report a POSIX-style relative source (e.g. `subdir/a.mthds`)
-        // even on Windows, where `fsPath` uses `\`. Normalize both sides to forward
-        // slashes before matching, so a path-qualified source is not misrouted by a
-        // separator mismatch (`\` vs `/`) in the basename or segment-boundary checks.
-        const src = error.source.replace(/\\/g, '/');
-        const srcBase = src.substring(src.lastIndexOf('/') + 1);
-        const isBareName = src === srcBase;
-        // A bare filename matches by basename; a path-qualified source (e.g. `foo/a.mthds`)
-        // must match exactly or on a path-segment boundary, so it can't misroute onto a
-        // similarly-named sibling like `/project/bar/a.mthds` via either branch.
-        const match = files.find(f => {
-            const fsPath = f.uri.fsPath.replace(/\\/g, '/');
-            const fsBase = fsPath.substring(fsPath.lastIndexOf('/') + 1);
-            const name = f.name.replace(/\\/g, '/');
-            return (
-                name === src ||
-                fsPath === src ||
-                (isBareName && fsBase === srcBase) ||
-                fsPath.endsWith('/' + src)
-            );
-        });
+        const match = matchSourceFile(error.source, files);
         if (match) {
             return match;
         }
     }
 
+    const domainCode = error.domain_code ?? undefined;
+
     const pipeCode = error.pipe_code ?? undefined;
     if (pipeCode) {
-        const match = files.find(f => findTableHeaderInLines(getLines(f), 'pipe', pipeCode) !== -1);
+        const match = findDeclaringFileByScan('pipe', pipeCode, files, domainCode, getLines);
         if (match) {
             return match;
         }
@@ -147,7 +140,7 @@ function resolveOwner(
 
     const conceptCode = error.concept_code ?? undefined;
     if (conceptCode) {
-        const match = files.find(f => findTableHeaderInLines(getLines(f), 'concept', conceptCode) !== -1);
+        const match = findDeclaringFileByScan('concept', conceptCode, files, domainCode, getLines);
         if (match) {
             return match;
         }

--- a/editors/vscode/src/pipelex/validation/graphPrimary.ts
+++ b/editors/vscode/src/pipelex/validation/graphPrimary.ts
@@ -1,0 +1,63 @@
+import * as vscode from 'vscode';
+import { gatherBundleFiles } from './bundleGather';
+import type { BundleFile } from './backend';
+
+const DEFAULT_BUNDLE_NAME = 'bundle.mthds';
+
+export interface GraphPrimaryBundle {
+    /** The file whose `main_pipe` should anchor graph generation. */
+    primaryUri: vscode.Uri;
+    /** Gathered bundle files, reordered so `primaryUri` is first when present. */
+    files: BundleFile[];
+}
+
+/**
+ * Resolve the graph-analysis anchor for an opened `.mthds` file.
+ *
+ * Most graph opens are for the real bundle file, but users often open an
+ * ancillary sibling (signatures, concepts, helper pipes) inside a directory
+ * whose `bundle.mthds` declares the method's `main_pipe`. In that case the
+ * graph should still be generated from the directory's main bundle.
+ */
+export async function resolveGraphPrimaryBundle(openedUri: vscode.Uri): Promise<GraphPrimaryBundle> {
+    let files: BundleFile[];
+    try {
+        files = await gatherBundleFiles(openedUri);
+    } catch {
+        return { primaryUri: openedUri, files: [] };
+    }
+    const primary = selectGraphPrimaryFile(openedUri, files);
+    return {
+        primaryUri: primary?.uri ?? openedUri,
+        files: primary ? reorderFilesWithPrimary(files, primary.uri) : files,
+    };
+}
+
+export function selectGraphPrimaryFile(openedUri: vscode.Uri, files: BundleFile[]): BundleFile | undefined {
+    const opened = files.find(file => file.uri.toString() === openedUri.toString()) ?? files[0];
+    if (!opened) return undefined;
+
+    if (hasTopLevelMainPipe(opened.content)) {
+        return opened;
+    }
+
+    const filesWithMain = files.filter(file => hasTopLevelMainPipe(file.content));
+    const defaultBundle = filesWithMain.find(file => file.name.toLowerCase() === DEFAULT_BUNDLE_NAME);
+    return defaultBundle ?? filesWithMain[0] ?? opened;
+}
+
+export function hasTopLevelMainPipe(content: string): boolean {
+    for (const line of content.split(/\r\n|\r|\n/)) {
+        if (/^\s*\[/.test(line)) return false;
+        if (/^\s*main_pipe\s*=\s*(["'])[^"']+\1\s*(?:#.*)?$/.test(line)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function reorderFilesWithPrimary(files: BundleFile[], primaryUri: vscode.Uri): BundleFile[] {
+    const index = files.findIndex(file => file.uri.toString() === primaryUri.toString());
+    if (index <= 0) return files;
+    return [files[index], ...files.slice(0, index), ...files.slice(index + 1)];
+}

--- a/editors/vscode/src/pipelex/validation/graphPrimary.ts
+++ b/editors/vscode/src/pipelex/validation/graphPrimary.ts
@@ -20,12 +20,7 @@ export interface GraphPrimaryBundle {
  * graph should still be generated from the directory's main bundle.
  */
 export async function resolveGraphPrimaryBundle(openedUri: vscode.Uri): Promise<GraphPrimaryBundle> {
-    let files: BundleFile[];
-    try {
-        files = await gatherBundleFiles(openedUri);
-    } catch {
-        return { primaryUri: openedUri, files: [] };
-    }
+    const files = await gatherBundleFiles(openedUri);
     const primary = selectGraphPrimaryFile(openedUri, files);
     return {
         primaryUri: primary?.uri ?? openedUri,

--- a/editors/vscode/src/pipelex/validation/pipelexValidator.ts
+++ b/editors/vscode/src/pipelex/validation/pipelexValidator.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { cancelInflightByKey, cancelInflightInDir } from './processUtils';
 import { gatherBundleFiles } from './bundleGather';
+import { resolveGraphPrimaryBundle } from './graphPrimary';
 import { buildBundleDiagnostics } from './crossFileDiagnostics';
 import { AnalyzeAbortError, BackendError } from './backend';
 import type { BackendFactory } from './backendFactory';
@@ -132,9 +133,13 @@ export class PipelexValidator implements vscode.Disposable {
 
         try {
             const backend = this.factory.getBackend(document.uri);
-            const files = await gatherBundleFiles(document.uri);
+            const graphPrimary = withGraph
+                ? await resolveGraphPrimaryBundle(document.uri)
+                : undefined;
+            const analysisPrimaryUri = graphPrimary?.primaryUri ?? document.uri;
+            const files = graphPrimary?.files ?? await gatherBundleFiles(document.uri);
             const analysis = await backend.analyze(
-                { primaryUri: document.uri, files, cwd: workspaceFolder?.uri.fsPath, timeout },
+                { primaryUri: analysisPrimaryUri, files, cwd: workspaceFolder?.uri.fsPath, timeout },
                 { withGraph, direction },
                 controller.signal,
             );

--- a/editors/vscode/src/pipelex/validation/pipelexValidator.ts
+++ b/editors/vscode/src/pipelex/validation/pipelexValidator.ts
@@ -150,7 +150,7 @@ export class PipelexValidator implements vscode.Disposable {
             // per-file and guarded separately by the panel's own currentUri check, so it
             // still updates for the file the user is viewing.
             if (this.dirGeneration.get(dir) === myGen) {
-                this.applyValidation(document, files, analysis);
+                this.applyValidation(document, analysisPrimaryUri, files, analysis);
                 this.lastNotifiedMessage = undefined;
             }
 
@@ -179,6 +179,7 @@ export class PipelexValidator implements vscode.Disposable {
 
     private applyValidation(
         document: vscode.TextDocument,
+        analysisPrimaryUri: vscode.Uri,
         files: { uri: vscode.Uri; name: string; content: string }[],
         analysis: BundleAnalysis,
     ): void {
@@ -191,7 +192,7 @@ export class PipelexValidator implements vscode.Disposable {
         const fileDiags = buildBundleDiagnostics({
             errors: validation.errors,
             files,
-            primaryUri: document.uri,
+            primaryUri: analysisPrimaryUri,
             diagnosticSource: DIAGNOSTIC_SOURCE,
             primaryDocument: document,
         });

--- a/editors/vscode/src/pipelex/validation/sourceLocator.ts
+++ b/editors/vscode/src/pipelex/validation/sourceLocator.ts
@@ -121,6 +121,6 @@ function fullLineRange(lines: string[], line: number): vscode.Range {
     return new vscode.Range(safeLine, 0, safeLine, lines[safeLine].length);
 }
 
-function escapeRegex(s: string): string {
+export function escapeRegex(s: string): string {
     return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/wip/code-review-cross-file-pipe-navigation.md
+++ b/wip/code-review-cross-file-pipe-navigation.md
@@ -1,0 +1,91 @@
+# Code review — cross-file pipe-node graph navigation
+
+Workflow-backed review (xhigh effort) of the staged changes. 10 finder angles, every candidate independently verified: 38 candidates → 25 kept, 13 refuted, 15 reported.
+
+**Scope of the change:** adds cross-file pipe-node graph navigation (click a pipe node in the graph panel → jump to its declaration in a sibling `.mthds`). The correctness issues cluster around node-identity recovery and a disk-resolution / line-find seam.
+
+## Root-cause clusters
+
+The 15 findings collapse into a handful of root causes. Fix the cluster, not the individual lines.
+
+| Cluster | Findings | Root cause | One-shot fix |
+| --- | --- | --- | --- |
+| **A — Node-identity / source-tier-vs-scan-fallback seam** | #1, #2, #3, #4 | `lookupPipeNode` recovers node identity by bare `pipe_code` and only consults the registry under `domain.code`; the source tier returns a file by path without verifying the header, so a stale/missing `source` defeats the scan fallback instead of falling through to it. | Make `lookupPipeNode` consult the registry under both `domain.code` and `.code` keys, and treat a registry `source` as a *hint* that still falls through to the header scan when the header isn't found in the resolved file. Knocks out #1, #3, #4 together; #2 needs domain-aware node matching. |
+| **B — Staleness across async / panel switches** | #5, #6 | Panel state (`currentGraphspec`, captured `primaryUri`) can outlive the graph it described — never reset on transition, never re-validated after awaits. | Reset `currentGraphspec` on every primary-file / error-view transition, and add the post-await staleness re-check that `renderValidationErrors` already has. |
+| **C — Resolution heuristics over-match** | #7, #8 | First-match + loose regex in `bundleResolution.ts` route to the wrong sibling on basename collisions / malformed lines. | Disambiguate bare-basename matches (path-aware), tighten the domain regex (balanced quotes). |
+| **D — Testing & docs gaps** | #9, #10 | New domain-disambiguation behavior is untested at the diagnostics-integration level; user-visible feature ships without a CHANGELOG entry. | Add a `crossFileDiagnostics.test.ts` case for the domain-collision branch; add the `[Unreleased]` CHANGELOG note. |
+| **E — Cleanup / efficiency** | #11, #12, #13, #14, #15 | Redundant per-click I/O, non-memoized line-splitting, duplicated `escapeRegex`, full-scan-per-error, and a non-generalized lookup helper. | Mechanical cleanups; see each finding. |
+
+---
+
+## 🔴 Cluster A — Correctness: node-identity / source-tier seam (confirmed)
+
+### 1. Domain-less nodes skip the registry `source` tier — `methodGraphPanel.ts:813`
+`lookupPipeNode` only reads `pipe_registry[\`${domainCode}.${pipeCode}\`].source` when the node carries a `domain_code`. But the runtime keys domain-less pipes under `.code` (empty domain prefix). So for a node with no/empty `domain_code`, the exact `source` is never used — a signature/concrete split falls back to the header scan and the click lands on the **signature in the primary file** instead of the concrete impl in the sibling.
+
+### 2. Bare `pipe_code` match picks the wrong domain on collision — `methodGraphPanel.ts:811`
+`lookupPipeNode` matches the clicked node by bare `pipe_code` only. When two nodes share a `pipe_code` across domains, the *first* node match supplies the `domain_code`, which can select the wrong registry `source` → clicking the second-domain node opens the first domain's declaration. (Documented as a known v1 edge, but still a user-visible misroute.)
+
+### 3. Source-first tier never verifies the header exists → silent click failure — `methodGraphPanel.ts:846`
+`navigateToPipe` resolves the owner file via `resolveDeclaringFile` (disk content), then re-finds the line through a separate `openTextDocument` + `findTableHeader`. The source tier returns a file *by path* without checking the `[pipe.<code>]` header is actually there. If the registry `source` is stale (pipe moved after graph generation, or a basename collision), `findTableHeader` returns -1 and the click dies logging "Could not find [pipe.<code>]" — **even though a plain header scan across the other gathered siblings would have found it.**
+
+### 4. Disk-resolution vs live-buffer seam on unsaved edits — `methodGraphPanel.ts:845`
+`resolveDeclaringFile` scans gathered **on-disk** content, but the line is located by scanning the **live buffer** of the opened doc. If a sibling is open with unsaved edits that deleted/moved its `[pipe.code]` header, disk still says "this file declares it," the buffer scan finds nothing, and the click is a silent no-op on a clearly-present node.
+
+---
+
+## 🟠 Cluster B — Correctness: staleness across async / panel switches (confirmed)
+
+### 5. Stale `currentGraphspec` outlives its graph across panel switches — `methodGraphPanel.ts:76` / `:603`
+`currentGraphspec` is set only on send and cleared only on dispose — never reset when the panel switches to a new primary file or to the error view. Open graph for file A, switch to file B which fails validation (error view, no graph sent): `currentGraphspec` still holds A's spec. A late-delivered `navigateToPipe` click in that window resolves against A's registry and can jump the user into A's sibling for a pipe belonging to B's failed bundle.
+
+### 6. Missing post-await staleness guard in `navigateToPipe` — `methodGraphPanel.ts:829`
+`navigateToPipe` captures `primaryUri` at entry, then awaits `gatherBundleFiles` + `openTextDocument`, but never re-validates that the panel/file is still current after the awaits — unlike `renderValidationErrors`, which re-checks `this.currentUri?.toString() !== uri.toString()` and `this.panel` after its async gather. Click a node, then immediately switch files/close the panel mid-await → navigation completes against the stale URI and steals focus to the previous graph's file.
+
+---
+
+## 🟡 Cluster C — Correctness: resolution heuristics over-match (plausible)
+
+### 7. `matchSourceFile` first-match on bare-basename collision — `bundleResolution.ts:59`
+`files.find(...)` returns the first match; a bare-basename `source` matches every sibling sharing that basename (`foo/a.mthds` vs `bar/a.mthds`). Navigation/diagnostics land on whichever appears first in gather order. (The test at :138 asserts this first-match behavior as intended — but it's a real misroute for ambiguous basenames.)
+
+### 8. `fileDeclaresDomain` regex over-matches — `bundleResolution.ts:96`
+`^\s*domain\s*=\s*["']<code>["']` allows mismatched quotes (`domain = "rec'`) and can match a `domain =` line that's actually an inline-structure value starting the line. Low likelihood in valid TOML; over-matching only.
+
+---
+
+## 🟡 Cluster D — Testing & docs gaps (confirmed)
+
+### 9. New domain-disambiguation diagnostics behavior is untested at the integration level — `crossFileDiagnostics.ts:135`
+`resolveOwner` now domain-prefers via `findDeclaringFileByScan(error.domain_code)`, but `crossFileDiagnostics.test.ts` was **not** updated. The only coverage is `bundleResolution.test.ts` calling `findDeclaringFileByScan` directly — nothing asserts that, for a code declared in two sibling files under different domains, the error now lands on the domain-matching file through `resolveOwner → resolveErrorLocations → buildBundleDiagnostics`. A future regression would keep the suite green.
+
+### 10. No CHANGELOG `[Unreleased]` entry — user-visible feature
+There's a feature doc but no CHANGELOG note, despite an active `[Unreleased]` section and direct precedent (0.10.0's "Interactive error view in graph panel" — the sibling feature this builds on). Both the workspace and repo CLAUDE.md require changelog/doc updates in the same change.
+
+---
+
+## 🟢 Cluster E — Cleanup / efficiency
+
+### 11. Redundant full-content gather on every click (confirmed) — `methodGraphPanel.ts:841`
+`navigateToPipe` reads the full content of every sibling `.mthds` on each click, even when the source tier resolves by path alone (`matchSourceFile` only touches uri/name). In the common modern-CLI case where `source` is present, all that file-content I/O is thrown away. Cheaper: a uri-only gather for the source tier; only read contents when falling through to the scan tier.
+
+### 12. `getLines` closure re-splits content, not memoized (confirmed) — `methodGraphPanel.ts:852`
+The `getLines` passed to `resolveDeclaringFile` re-splits each file on every call (twice per file on the domain-collision path), unlike `resolveErrorLocations` which memoizes splits in a per-uri `Map`. Reuse the same `linesCache` pattern.
+
+### 13. Duplicated `escapeRegex` (confirmed) — `bundleResolution.ts:109`
+Byte-identical copy of the private `escapeRegex` in `sourceLocator.ts:124` (same regex), and `bundleResolution.ts` already imports from `sourceLocator.ts`. Export the existing one and import it, so a future regex-escaping fix isn't needed in two places.
+
+### 14. Full-scan-per-error vs prior first-match (plausible) — `bundleResolution.ts:86`
+`findDeclaringFileByScan` uses `files.filter(...)` (scans every file) where the old `resolveOwner` used `find(...)` and short-circuited. Per error, for both pipe and concept scans → up to N regex-walks per error instead of stopping at the first match. The `matches.length <= 1` early-out only helps *after* the full filter runs. Noticeable on save-time validation of large bundles.
+
+### 15. `lookupPipeNode` not generalized for concepts (plausible) — `methodGraphPanel.ts:809`
+The node-identity recovery is hard-coded to pipes (bare `pipe_code` match), even though `resolveDeclaringFile` and the registry data are kind-symmetric. When concept-to-code navigation lands (named as a tight follow-up), a parallel `lookupConceptNode` will duplicate this logic — the very pipe/concept duplication `bundleResolution.ts` was extracted to eliminate.
+
+---
+
+## Suggested fix order
+
+1. **Cluster A** (#1, #3, #4 in one `lookupPipeNode` rework; #2 with domain-aware node matching) — highest user-visible impact.
+2. **Cluster B** (#5, #6) — the staleness pair.
+3. **Cluster D** (#10 CHANGELOG, #9 test) and **#13** escapeRegex — cheap, required by CLAUDE.md.
+4. **Cluster C** (#7, #8) and remaining **Cluster E** (#11, #12, #14, #15) — decide case by case.

--- a/wip/cross-file-pipe-navigation.md
+++ b/wip/cross-file-pipe-navigation.md
@@ -1,0 +1,98 @@
+# Cross-file pipe-node navigation
+
+Plan for making "click a pipe node in the method graph → reveal its code" work across `.mthds` files in the same bundle directory, not just the single file the panel was opened from. Scope (decided): **pipes only**, **strictly click-to-code** — concept navigation and `--pipe` graph-targeting are explicitly out of scope here and tracked as follow-ups (see "Deferred").
+
+## Status: IMPLEMENTED (Phases 1–5 complete)
+
+All five phases landed. Cross-file pipe navigation works end-to-end with source-first resolution and a scan fallback.
+
+- **Upstream dependency confirmed.** The local editable `pipelex` (pinned by `../pipelex-demos`) emits `pipe_registry[ref].source` as **absolute paths**. Verified against `pipelex-demos/mthds-wip/recruitment_recursive`, a real signature/concrete split where `screen_candidates`'s `source` correctly points at the concrete `screen_candidates.mthds` (not the signature in `bundle.mthds`). Note: the global `pipelex-agent` on `PATH` is an older release that omits `source` — run via the demos venv (`pipelex-demos/.venv/bin/pipelex-agent`) to see it.
+- **Phase 1–3 (the shippable unit).** New `validation/bundleResolution.ts` holds the single owner resolver (`resolveDeclaringFile`, `matchSourceFile`, `findDeclaringFileByScan`); `crossFileDiagnostics.resolveOwner` now delegates to its primitives so the error path and the navigation path can't drift. `methodGraphPanel` retains the GraphSpec (`currentGraphspec`, cleared on dispose), recovers a clicked node's `domain_code` + registry `source` (`lookupPipeNode`), and `navigateToPipe` resolves source-first → scan → primary fallback, sharing the open-and-reveal tail (`revealRangeBeside`) with `navigateToError`. Webview message contract unchanged (still posts bare `pipeCode`).
+- **Phase 4 (tests).** `bundleResolution.test.ts` (unit: source variants, scan fallback, domain-disambiguated collision, not-found, path normalization) + new integration cases in `methodGraphPanel.test.ts` (source-first opens the concrete sibling; single-file regression; no-`source` scan fallback; synthesized-pipe silent log). Full extension suite green (`make test-ext`).
+- **Phase 5 (docs).** New `docs/features/graph-pipe-navigation.md`; cross-linked from `docs/features/validation-backends.md`.
+- **mthds-ui:** no update needed — everything consumed (`node.domain_code`, `pipe_registry[ref].source`) comes from the CLI GraphSpec; the bundled mthds-ui (v0.9.0) already fires `onNavigateToPipe`. The deferred bulletproof-identity upgrade (`onNodeSelect`) is also already available in v0.9.0, so it needs no bump either.
+- **Deferred items remain deferred:** concept-to-code navigation and `--pipe` graph-targeting (see "Deferred").
+
+## Problem
+
+When a method is split across several bundles in one directory (e.g. pipe *signatures* in one `.mthds`, concrete *implementations* in another), clicking a pipe node whose code lives in a sibling file does nothing but log "Could not find [pipe.<code>]".
+
+Root cause is a single hard-coded file. The click path is:
+
+- `webview/adapter.ts` `onNavigateToPipe(pipeCode)` → posts `{ type: 'navigateToPipe', pipeCode }` (only the bare code travels — no file, no domain).
+- `methodGraphPanel.ts` `handleWebviewMessage` → `navigateToPipe(pipeCode)` opens **`this.currentUri`** (the panel's primary file) and regex-scans *only that file* for `[pipe.<code>]` via `findTableHeader`. A sibling-declared pipe yields `-1` and the silent log.
+
+The cross-file capability already exists elsewhere in the extension — the **validation-error list is already cross-file**: `gatherBundleFiles()` reads every `.mthds` in the directory and `resolveOwner()` (`validation/crossFileDiagnostics.ts`) finds which file declares a `[pipe.<code>]` / `[concept.<code>]`, then `navigateToError()` opens that owning file beside the panel. Pipe-click navigation simply never got routed through the same machinery.
+
+## Approach: source-first, scan-as-fallback
+
+The pipelex worktree branch `feature/Graph-improve-2` (pending merge) adds a declaration **source path** to the graph registries: `pipe_registry[pipe_ref]["source"]` (and `concept_registry[concept_ref]["source"]`), populated from `LibraryCrate.source_map`, keyed by `pipe_ref` = `domain.code`, value = the declaring file's path. The field is **omitted when unknown** (never `null`), and the collision reconciler makes `source` follow the *winning* declaration — so for a signature/concrete pair it points at the concrete implementation. That is exactly the multi-bundle case this plan targets.
+
+So resolution is two-tier, and **feature-detected** (no `MIN_AGENT_VERSION` bump required):
+
+1. **Source (exact).** If the clicked pipe's registry entry carries `source`, resolve that path to an on-disk URI and open it. No heuristics; keys on `domain.code` so same-named pipes in different domains resolve correctly.
+2. **Scan (fallback).** If `source` is absent (older CLI, or unknown source), gather the sibling `.mthds` files and find the one that declares `[pipe.<code>]` — the existing error-path scan, optionally domain-filtered. Behaves like today's single-file path when the pipe is in the primary file.
+
+In both tiers the `source`/owning file is **file-level**; the exact *line* still comes from `findTableHeaderInLines` scanning the resolved file for the `[pipe.<code>]` header. pipelex deliberately does not own editor-range semantics — line-finding stays a presentation concern in the consumer.
+
+## Implementation
+
+### Phase 1 — Retain the graphspec + identify the clicked node
+
+- **Store the graphspec on the panel.** `sendGraphspecToWebview()` currently forwards the graphspec to the webview and discards it. Add `private currentGraphspec: GraphSpec | undefined` (cleared in `onDidDispose`, reset on every send). Needed to map a clicked pipe back to its registry `source` + `domain_code`.
+- **Resolve the clicked node's identity.** `onNavigateToPipe(pipeCode)` surfaces only `pipeCode`. The panel looks the node up in `currentGraphspec` by `pipe_code` to recover its `domain_code`, forms `pipe_ref = domain_code + "." + pipe_code`, and reads `pipe_registry[pipe_ref]?.source`.
+  - Edge: if the same `pipe_code` appears under two domains as two nodes in one graph, a bare `pipeCode` can't say which node was clicked. Acceptable for v1 (rare; the scan fallback still finds *a* correct declaration). The bulletproof upgrade is to also wire mthds-ui's `onNodeSelect(nodeId, nodeData)` — `nodeId` is unique and `nodeData` carries `domain_code` — and post `{ type: 'navigateToNode', nodeId }` instead. Recorded as an upgrade, not done here, to keep the message contract and the webview surface unchanged.
+
+### Phase 2 — Shared declaring-file resolver
+
+- **Extract a single resolver** so the error path and the navigation path can't drift (the "single source of truth for owner" intent is already stated in `crossFileDiagnostics.ts`). New small module, e.g. `validation/bundleResolution.ts`:
+  - `resolveDeclaringFile({ kind, code, domainCode?, source?, files }): vscode.Uri | undefined`
+  - Priority: (1) `source` path match — reuse `resolveOwner`'s existing `error.source` matching (slash-normalized; exact / basename / path-segment-suffix), which already tolerates absolute vs relative and bare-name vs path-qualified; (2) header scan `[kind.code]` across `files`, preferring the file whose `domain = "<domainCode>"` when `domainCode` is known.
+  - Refactor `crossFileDiagnostics.resolveOwner` to delegate to this resolver (errors keep their `error.source` → `pipe_code` → `concept_code` order; navigation passes `source` + `domainCode`).
+
+### Phase 3 — Rewrite `navigateToPipe`
+
+- New flow:
+  1. Look up node + `domain_code` + registry `source` from `currentGraphspec` (Phase 1).
+  2. `files = await gatherBundleFiles(this.currentUri)`.
+  3. `target = resolveDeclaringFile({ kind: 'pipe', code: pipeCode, domainCode, source, files })`.
+  4. If `target` is undefined → keep today's behavior (scan `this.currentUri`); if still nothing, the same silent log line.
+  5. Open `target` beside the panel and reveal the header line.
+- **Extract the open-and-reveal tail** shared with `navigateToError` (both compute `targetCol` from the panel column, `showTextDocument`, set selection, `revealRange(... InCenter)`). One helper, e.g. `revealLineBeside(uri, line)`.
+- **`graphspec-json` source kind stays disabled** for navigation (already guarded) — a run-graph JSON has no editable bundle in the workspace.
+
+### Phase 4 — Tests (unit + integration; keep single-file green)
+
+- **Unit — `resolveDeclaringFile`:** source-hit (absolute path, basename-only, relative-with-subdir), header-scan fallback, domain-disambiguated collision (two files, same `[pipe.process]`, different `domain`), not-found. Mirror the handler-test style in `crates/.../handlers/tests` / the extension's vitest layout.
+- **Integration — multi-bundle fixture:** a directory with a signature bundle and a concrete bundle; a graphspec whose `pipe_registry[ref].source` points at the concrete file; assert `navigateToPipe` opens the concrete file and lands on the `[pipe.<code>]` line. Add the fixture under `test-data/mthds/<feature>/`.
+- **Regression:** a pipe declared in the primary file still resolves to `currentUri` (no behavior change for the common single-file case).
+- **Fallback path:** a graphspec with **no** `source` in the registry must still resolve via the scan (proves feature-detection degrades cleanly on an older CLI).
+
+### Phase 5 — Docs
+
+- Update the extension docs describing the graph panel to cover cross-file pipe navigation, the source-first/scan-fallback resolution, and the feature-detection behavior across CLI versions. Note the unsaved-sibling caveat (the scan reads disk, matching the error path).
+
+## CHECKPOINT after Phase 3
+
+Phases 1–3 are a coherent, shippable unit: cross-file pipe navigation working end-to-end with the scan fallback, before tests/docs harden it. Natural handoff point — re-confirm the `source` field is present in a real CLI build (or still on the worktree) before relying on tier 1, and decide whether to also pursue the `onNodeSelect` upgrade. Tests (Phase 4) and docs (Phase 5) follow.
+
+## Decisions / edge cases recorded
+
+- **No `MIN_AGENT_VERSION` bump.** `source` is additive and feature-detected; the scan fallback covers older CLIs. (Revisit only if we decide to *guarantee* exact resolution.)
+- **Source path portability.** The resolver must tolerate absolute *and* relative `source` values (siblings load from a `.resolve()`-d parent dir → absolute; the primary's source is whatever path was passed). Reusing `resolveOwner`'s matching handles both. See the upstream feedback below — if pipelex normalizes `source`, this stays simple.
+- **Unsaved sibling buffers.** The scan reads from disk (consistent with the error path's documented v1 behavior); the opened document still shows the live buffer. Reading unsaved buffers for resolution is a deferred refinement.
+
+## Deferred (explicitly out of scope for this change)
+
+- **Concept-to-code navigation.** `concept_registry[ref].source` makes the *data* side symmetric, and `resolveDeclaringFile` already takes `kind: 'concept'`. The remaining work is the **UI affordance**: concept/stuff nodes currently open the data inspector on click (`onStuffNodeClick`), so deciding where "go to concept definition" lives (e.g. the detail panel's `onConceptClick(conceptRef)`, stripping any `domain.` prefix / `[]` multiplicity per the concept-reference rule) is a separate design. Tight follow-up — reuses everything here.
+- **`--pipe` graph-targeting.** Lets the panel graph a partial / no-`main_pipe` bundle by targeting a chosen pipe. Separable from click-to-code; folds the "graph a signature-only bundle" story together. See upstream feedback on the flag's shape before consuming it.
+
+## Upstream dependency — pipelex `feature/Graph-improve-2` (consumer feedback)
+
+This plan consumes the new registry `source` field. Feedback raised on that branch's shape (full notes in the review thread):
+
+- **Normalize `source` path format.** Today it is inconsistent: siblings are absolute (resolved parent dir), the primary is whatever path the caller passed. A consumer can't assume a shared base. Prefer one convention (relative to the bundle/library root, consumer resolves) and document it. Keep it consistent with `error.source` so both can be matched by the same logic.
+- **Absolute host paths in a wire artifact.** Fine for the local-CLI consumer (this extension), but if `GraphSpec` is ever returned by the API/hosted surface, leaking the server's absolute filesystem paths is wrong. Decide whether `source` is a local-only convenience or part of the contract; if the latter, make it root-relative.
+- **CLI `--pipe` conflates two concerns.** On the CLI, `--pipe X` narrows *both* validation (to the pipe slice via `validate_pipe_in_bundle_core`) *and* the graph target. The protocol's `extra={"graph_pipe_code": X}` only retargets the *graph* and keeps whole-bundle validation. A CLI consumer that wants whole-bundle (cross-file) diagnostics **and** a graph of a chosen pipe has no flag for that. Consider a graph-only target on the CLI (distinct from `--pipe`), or document the validation-narrowing clearly.
+- **`extra` bag vs typed param.** `graph_pipe_code` rides in an untyped `extra: dict[str, Any]` on the protocol's `validate`. For a spec'd MTHDS-protocol surface a typed field is more discoverable and validatable; if this is documented in `docs/specs/`, keep spec + conformance in sync.
+- **Test the multi-file round-trip.** Coverage was added for passthrough/precedence; add a test asserting `pipe_registry[ref].source` (and the concept one) point at the correct *sibling* file for a genuine multi-bundle directory — that is the property this extension feature relies on.


### PR DESCRIPTION
## Summary

This PR improves MTHDS pipe navigation across multi-file bundle directories.

- Makes Cmd-click / go-to-definition prefer concrete pipe declarations over matching `PipeSignature` stubs in sibling `.mthds` files.
- Extends method graph pipe-node navigation to resolve cross-file declarations through registry `source` paths, with scan fallback for older backends.
- Adds graph primary selection so opening an ancillary signature/concept/helper file can still render the bundle's main graph.
- Keeps cross-file validation diagnostics and graph navigation aligned through shared declaration-resolution helpers.
- Documents the cross-file graph-navigation behavior.

## Root Cause

The editor and graph navigation paths were resolving `[pipe.<code>]` declarations in too-local a way. In signature/concrete splits, the primary or currently open file could contain only `type = "PipeSignature"`, so navigation stopped at the contract instead of the implementation.

## Validation

- `cargo test -p taplo-lsp`
- `cargo check -p pipelex-wasm --target wasm32-unknown-unknown`
- `corepack yarn test src/pipelex/__tests__/bundleResolution.test.ts src/pipelex/__tests__/methodGraphPanel.test.ts`
- `corepack yarn typecheck`
- `make ext`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves MTHDS navigation to prefer concrete pipe implementations and makes cross-file jumps work from both Cmd-click/go-to-definition and the method graph. Also adds graph-primary resolution so opening helper/signature files still renders the bundle’s main graph.

- **New Features**
  - Cmd-click/go-to-definition in `.mthds` resolves `[pipe.<code>]` to the concrete declaration across sibling files. Uses runtime `source` paths first, then scans as fallback.
  - Method graph: clicking a pipe node opens its declaration across files and preserves domain identity when codes repeat. Node selection is tracked so the correct domain/file is opened.
  - Cross-file diagnostics and graph navigation share one owner resolver. Clicking an error opens the correct sibling file at the exact line. Docs added for cross-file pipe navigation.

- **Refactors**
  - Introduced `resolveDeclaringFile` and graph-primary helpers used by the webview, validator, and diagnostics for consistent behavior.
  - Extended LSP `goto_definition` to classify references and prefer concrete pipe targets; added unit/integration tests for bundle resolution, graph primary, diagnostics, and panel behavior.

<sup>Written for commit 670e6112c1606bce19b0fdcce2ee2ba8d71b7bfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/vscode-pipelex/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

