### PR TITLE
chore(deps): bump @pipelex/sdk to 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Pipelex IDE Extension and `plxt` CLI Changelog
 
+## [0.12.1] - 2026-06-30
+
+### Changed
+ - **API validation backend moved to `@pipelex/sdk`'s `PipelexApiClient`** (from `mthds`'s `MthdsApiClient`). The Pipelex-API `/v1/validate` narrowing now lives in `@pipelex/sdk` — the `mthds` package exposes only the standard's neutral verdict — so the extension takes its typed validation client and `PipelexValidationResult` from the SDK and drops the direct `mthds` dependency (it arrives transitively via the SDK). **Breaking:** the hosted-API token's environment-variable fallback is now `PIPELEX_API_KEY` (was `MTHDS_API_KEY`) — set a key with the "Pipelex: Set Hosted API Key" command or the `PIPELEX_API_KEY` env var.
+
+### Fixed
+ - **`PipeStructure` nodes no longer blank the method graph:** Bumped `@pipelex/mthds-ui` to 0.11.0. A method containing a `PipeStructure` operator (an LLM-backed pipe that turns `Text` into a structured concept) now renders as an ordinary operator card instead of throwing a validation error and collapsing the entire graph to a "Failed to render method graph" screen. The detail panel surfaces its structuring config (model — including an inline `llm_choice` setting — text variable, output multiplicity, and rendered prompt), and any operator or controller node whose blueprint can't be resolved now falls back to the generic execution-data dump rather than hiding its runtime values.
+
 ## [0.12.0] - 2026-06-29
 
 ### Added

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 # Pipelex IDE Extension and `plxt` CLI Changelog
 
+## [0.12.1] - 2026-06-30
+
+### Changed
+ - **API validation backend moved to `@pipelex/sdk`'s `PipelexApiClient`** (from `mthds`'s `MthdsApiClient`). The Pipelex-API `/v1/validate` narrowing now lives in `@pipelex/sdk` — the `mthds` package exposes only the standard's neutral verdict — so the extension takes its typed validation client and `PipelexValidationResult` from the SDK and drops the direct `mthds` dependency (it arrives transitively via the SDK). **Breaking:** the hosted-API token's environment-variable fallback is now `PIPELEX_API_KEY` (was `MTHDS_API_KEY`) — set a key with the "Pipelex: Set Hosted API Key" command or the `PIPELEX_API_KEY` env var.
+
+### Fixed
+ - **`PipeStructure` nodes no longer blank the method graph:** Bumped `@pipelex/mthds-ui` to 0.11.0. A method containing a `PipeStructure` operator (an LLM-backed pipe that turns `Text` into a structured concept) now renders as an ordinary operator card instead of throwing a validation error and collapsing the entire graph to a "Failed to render method graph" screen. The detail panel surfaces its structuring config (model — including an inline `llm_choice` setting — text variable, output multiplicity, and rendered prompt), and any operator or controller node whose blueprint can't be resolved now falls back to the generic execution-data dump rather than hiding its runtime values.
+
 ## [0.12.0] - 2026-06-29
 
 ### Added

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -827,7 +827,7 @@
   "dependencies": {
     "@pipelex/lsp": "portal:../../js/lsp",
     "@pipelex/mthds-ui": "npm:0.11.0",
-    "@pipelex/sdk": "0.1.4",
+    "@pipelex/sdk": "0.1.5",
     "deep-equal": "^2.2.3",
     "encoding": "^0.1.13",
     "fast-glob": "^3.3.2",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "pipelex",
   "displayName": "Pipelex",
   "description": "Pipelex extension for the MTHDS language",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "repository": {
     "url": "https://github.com/Pipelex/vscode-pipelex"
   },
@@ -826,11 +826,11 @@
   },
   "dependencies": {
     "@pipelex/lsp": "portal:../../js/lsp",
-    "@pipelex/mthds-ui": "npm:0.10.0",
+    "@pipelex/mthds-ui": "npm:0.11.0",
+    "@pipelex/sdk": "0.1.4",
     "deep-equal": "^2.2.3",
     "encoding": "^0.1.13",
     "fast-glob": "^3.3.2",
-    "mthds": "npm:0.12.0",
     "node-fetch": "^3.3.2",
     "react": "^19",
     "react-dom": "^19",

--- a/editors/vscode/src/pipelex/__tests__/apiValidationBackend.test.ts
+++ b/editors/vscode/src/pipelex/__tests__/apiValidationBackend.test.ts
@@ -13,9 +13,9 @@ vi.mock('vscode', () => ({
     window: { showWarningMessage: vi.fn() },
 }));
 
-// ---------- mthds mock (classes defined inside the hoisted factory) ----------
-vi.mock('mthds', () => {
-    // Mirror the real `mthds` constructor signatures (message-first) so the
+// ---------- @pipelex/sdk mock (classes defined inside the hoisted factory) ----------
+vi.mock('@pipelex/sdk', () => {
+    // Mirror the real `@pipelex/sdk` constructor signatures (message-first) so the
     // call sites below type-check against the imported real classes, while the
     // backend still reads `.status`/`.serverMessage`/`.statusText`/`.code`.
     class ApiResponseError extends Error {
@@ -28,6 +28,7 @@ vi.mock('mthds', () => {
             public errorType: string | undefined,
             public serverMessage: string | undefined,
             public validationErrors: any[] | undefined,
+            public code: string | undefined,
         ) {
             super(message);
             this.name = 'ApiResponseError';
@@ -49,7 +50,7 @@ vi.mock('mthds', () => {
             this.name = 'PipelineRequestError';
         }
     }
-    class MthdsApiClient {
+    class PipelexApiClient {
         constructor(options: any) {
             apiState.lastConstructorOptions = options;
             // Mirror the real client: reject a non-host-only base URL (the common
@@ -67,10 +68,10 @@ vi.mock('mthds', () => {
             return apiState.version ? apiState.version() : { protocol_version: '1', implementation_version: '0.4.0' };
         }
     }
-    return { MthdsApiClient, ApiResponseError, ApiUnreachableError, PipelineRequestError };
+    return { PipelexApiClient, ApiResponseError, ApiUnreachableError, PipelineRequestError };
 });
 
-import { ApiResponseError, ApiUnreachableError } from 'mthds';
+import { ApiResponseError, ApiUnreachableError } from '@pipelex/sdk';
 import { ApiValidationBackend } from '../validation/apiValidationBackend';
 import { ApiVersionGate } from '../validation/apiVersionGate';
 import { BackendError } from '../validation/backend';
@@ -198,14 +199,14 @@ describe('ApiValidationBackend', () => {
     it('maps a request-shape 422 (no verdict) to an api-error BackendError', async () => {
         // `/validate` never 422s a content verdict now — a 422 is a request-shape
         // problem (e.g. mthds_sources length mismatch), surfaced as api-error.
-        apiState.validate = async () => { throw new ApiResponseError('mthds_sources length must match mthds_contents', 'http://localhost:8081', 422, 'Unprocessable Entity', '', 'ValidationError', 'mthds_sources length must match mthds_contents', undefined); };
+        apiState.validate = async () => { throw new ApiResponseError('mthds_sources length must match mthds_contents', 'http://localhost:8081', 422, 'Unprocessable Entity', '', 'ValidationError', 'mthds_sources length must match mthds_contents', undefined, undefined); };
         const err = await analyze(makeBackend()).catch(e => e);
         expect(err).toBeInstanceOf(BackendError);
         expect(err.kind).toBe('api-error');
     });
 
     it('maps a self-hosted 401 to an auth BackendError with a single Set-API-Key action', async () => {
-        apiState.validate = async () => { throw new ApiResponseError('unauthorized', 'http://localhost:8081', 401, 'Unauthorized', '', 'AuthError', 'unauthorized', undefined); };
+        apiState.validate = async () => { throw new ApiResponseError('unauthorized', 'http://localhost:8081', 401, 'Unauthorized', '', 'AuthError', 'unauthorized', undefined, undefined); };
         const err = await analyze(makeBackend()).catch(e => e); // default baseUrl is localhost (self-hosted)
         expect(err).toBeInstanceOf(BackendError);
         expect(err.kind).toBe('auth');
@@ -219,7 +220,7 @@ describe('ApiValidationBackend', () => {
     });
 
     it('maps a hosted 401/403 to an auth BackendError with Set + Get-a-key actions and clickable rich detail', async () => {
-        apiState.validate = async () => { throw new ApiResponseError('forbidden', 'https://api.pipelex.com', 403, 'Forbidden', '', 'AuthError', 'forbidden', undefined); };
+        apiState.validate = async () => { throw new ApiResponseError('forbidden', 'https://api.pipelex.com', 403, 'Forbidden', '', 'AuthError', 'forbidden', undefined, undefined); };
         const err = await analyze(makeBackend({ baseUrl: 'https://api.pipelex.com' })).catch(e => e);
         expect(err).toBeInstanceOf(BackendError);
         expect(err.kind).toBe('auth');
@@ -238,7 +239,7 @@ describe('ApiValidationBackend', () => {
     });
 
     it('maps a 5xx to an api-error BackendError (server reached, errored)', async () => {
-        apiState.validate = async () => { throw new ApiResponseError('service unavailable', 'https://api.pipelex.com', 503, 'Service Unavailable', '', undefined, 'service unavailable', undefined); };
+        apiState.validate = async () => { throw new ApiResponseError('service unavailable', 'https://api.pipelex.com', 503, 'Service Unavailable', '', undefined, 'service unavailable', undefined, undefined); };
         const err = await analyze(makeBackend({ baseUrl: 'https://api.pipelex.com' })).catch(e => e);
         expect(err).toBeInstanceOf(BackendError);
         expect(err.kind).toBe('api-error');

--- a/editors/vscode/src/pipelex/validation/apiKey.ts
+++ b/editors/vscode/src/pipelex/validation/apiKey.ts
@@ -16,8 +16,8 @@ const PIPELEX_API_KEY_PREFIX = 'plx_sk_';
  * Resolve the API token with SecretStorage → environment precedence.
  *
  * A stored secret (set via `Pipelex: Set Hosted API Key`) wins. When none is
- * stored we return `undefined`, letting `MthdsApiClient` fall back to its native
- * `MTHDS_API_KEY` env read — so the wrapper overrides the env when a key is
+ * stored we return `undefined`, letting `PipelexApiClient` fall back to its native
+ * `PIPELEX_API_KEY` env read — so the wrapper overrides the env when a key is
  * stored, and defers to it otherwise. The token is never read from settings
  * (plaintext), by design.
  */

--- a/editors/vscode/src/pipelex/validation/apiValidationBackend.ts
+++ b/editors/vscode/src/pipelex/validation/apiValidationBackend.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import { MthdsApiClient, ApiResponseError, ApiUnreachableError, PipelineRequestError } from 'mthds';
-import type { PipelexInvalidReport, PipelexValidationReport, PipelexValidationResult } from 'mthds';
+import { PipelexApiClient, ApiResponseError, ApiUnreachableError, PipelineRequestError } from '@pipelex/sdk';
+import type { PipelexInvalidReport, PipelexValidationReport, PipelexValidationResult } from '@pipelex/sdk';
 import { AnalyzeAbortError, BackendError } from './backend';
 import type { AnalyzeOptions, BackendErrorAction, BundleAnalysis, BundleRequest, ValidationBackend, ValidationOutcome } from './backend';
 import type { ValidationErrorItem } from './types';
@@ -55,10 +55,10 @@ export class ApiValidationBackend implements ValidationBackend {
         // non-host-only `pipelex.api.baseUrl`, e.g. one with a `/v1` path). Doing it here,
         // inside a try, turns a misconfiguration into an actionable BackendError instead
         // of a throw that escapes `handleError` — and fails fast, before the privacy modal.
-        let client: MthdsApiClient;
+        let client: PipelexApiClient;
         try {
             const token = await this.deps.getToken();
-            client = new MthdsApiClient({ baseUrl, apiToken: token });
+            client = new PipelexApiClient({ baseUrl, apiToken: token });
         } catch (err: unknown) {
             throw setupError(err, baseUrl);
         }
@@ -327,7 +327,7 @@ function authMessage(baseUrl: string, status: number): string {
             `locally with Docker, or switch \`pipelex.backend\` to \`cli\` to validate without a key.`;
     }
     return `The Pipelex API at ${baseUrl} rejected the request (HTTP ${status}) — it requires authentication. ` +
-        `Set a key with the "Pipelex: Set Hosted API Key" command (or set the MTHDS_API_KEY environment variable). ` +
+        `Set a key with the "Pipelex: Set Hosted API Key" command (or set the PIPELEX_API_KEY environment variable). ` +
         `You can also switch \`pipelex.backend\` to \`cli\` to validate locally.`;
 }
 
@@ -350,7 +350,7 @@ function authDetailHtml(baseUrl: string, status: number): string {
             `to validate locally.`;
     }
     return `The Pipelex API at ${host} rejected the request (HTTP ${status}) — it requires authentication.` +
-        `</p><p>Click <strong>Set API Key</strong> below, or set the <code>MTHDS_API_KEY</code> environment ` +
+        `</p><p>Click <strong>Set API Key</strong> below, or set the <code>PIPELEX_API_KEY</code> environment ` +
         `variable. You can also switch <code>pipelex.backend</code> to <code>cli</code> to validate locally.`;
 }
 

--- a/editors/vscode/src/pipelex/validation/apiVersionGate.ts
+++ b/editors/vscode/src/pipelex/validation/apiVersionGate.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import type { MthdsApiClient } from 'mthds';
+import type { PipelexApiClient } from '@pipelex/sdk';
 import { type Semver, compareSemver, formatSemver } from './agentCliVersion';
 
 /**
@@ -98,7 +98,7 @@ export class ApiVersionGate {
      * callers (tests) can probe without an abort context.
      */
     async ensureCapable(
-        client: MthdsApiClient,
+        client: PipelexApiClient,
         baseUrl: string,
         signal?: AbortSignal,
         timeoutMs?: number,

--- a/editors/vscode/yarn.lock
+++ b/editors/vscode/yarn.lock
@@ -505,9 +505,9 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@pipelex/mthds-ui@npm:0.10.0":
-  version: 0.10.0
-  resolution: "@pipelex/mthds-ui@npm:0.10.0"
+"@pipelex/mthds-ui@npm:0.11.0":
+  version: 0.11.0
+  resolution: "@pipelex/mthds-ui@npm:0.11.0"
   dependencies:
     "@xyflow/react": "npm:^12"
     dompurify: "npm:^3.3.3"
@@ -523,7 +523,16 @@ __metadata:
       optional: true
     shiki:
       optional: true
-  checksum: 7ef5f10a5b0aef6a815d872bc1360719c37fda00f380175757a97ffe3f5ec693e4b7c71a297c78f4fa20e8f257dc4292efa2dd9647db48a835d1e169de80f8dc
+  checksum: c4e1ae0040f60c69c09d51d08a07591e1d794438ad37cd2a038f541b08ca6a24d33b7a16fa8df762f187a918039c67556a55a4d64ef694bd917e1edce05911e8
+  languageName: node
+  linkType: hard
+
+"@pipelex/sdk@npm:0.1.4":
+  version: 0.1.4
+  resolution: "@pipelex/sdk@npm:0.1.4"
+  dependencies:
+    mthds: "npm:^0.14.0"
+  checksum: dd1fb36e88977c767ceff837c0fea1bb1d70b7c20a5eab762f9ea88c96a8e4a9c121bb9fd5f8ea25efb0f1cf9358ae021bf0f6d7636bf1fca47651061856a1c2
   languageName: node
   linkType: hard
 
@@ -3462,9 +3471,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mthds@npm:0.12.0":
-  version: 0.12.0
-  resolution: "mthds@npm:0.12.0"
+"mthds@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "mthds@npm:0.14.0"
   dependencies:
     "@clack/prompts": "npm:^1.0.0"
     chalk: "npm:^5.4.1"
@@ -3477,7 +3486,7 @@ __metadata:
   bin:
     mthds: dist/cli.js
     mthds-agent: dist/agent-cli.js
-  checksum: 1c0353ae86e1fca1b57629d46fbb7e2e365b3f8ef2680a5e6644d685525d797d4daa6898aa3c876a060ce73ef2e4833b9fd1025c04d6f4e54c8514146a497414
+  checksum: f234c876a9066688df1b743ae0f0cc8c22c46c1d19f6fd75ef3fae84692c7091b57b5d29bbdee175f7bb37f0ea57419e5f6f7e7d52297fb68e38cd413caccf5b
   languageName: node
   linkType: hard
 
@@ -3775,7 +3784,8 @@ __metadata:
   resolution: "pipelex@workspace:."
   dependencies:
     "@pipelex/lsp": "portal:../../js/lsp"
-    "@pipelex/mthds-ui": "npm:0.10.0"
+    "@pipelex/mthds-ui": "npm:0.11.0"
+    "@pipelex/sdk": "npm:0.1.4"
     "@rollup/plugin-commonjs": "npm:^25.0.7"
     "@rollup/plugin-node-resolve": "npm:^15.2.3"
     "@rollup/plugin-replace": "npm:^5.0.5"
@@ -3790,7 +3800,6 @@ __metadata:
     encoding: "npm:^0.1.13"
     esbuild: "npm:^0.20.0"
     fast-glob: "npm:^3.3.2"
-    mthds: "npm:0.12.0"
     node-fetch: "npm:^3.3.2"
     react: "npm:^19"
     react-dom: "npm:^19"

--- a/editors/vscode/yarn.lock
+++ b/editors/vscode/yarn.lock
@@ -527,12 +527,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pipelex/sdk@npm:0.1.4":
-  version: 0.1.4
-  resolution: "@pipelex/sdk@npm:0.1.4"
+"@pipelex/sdk@npm:0.1.5":
+  version: 0.1.5
+  resolution: "@pipelex/sdk@npm:0.1.5"
   dependencies:
-    mthds: "npm:^0.14.0"
-  checksum: dd1fb36e88977c767ceff837c0fea1bb1d70b7c20a5eab762f9ea88c96a8e4a9c121bb9fd5f8ea25efb0f1cf9358ae021bf0f6d7636bf1fca47651061856a1c2
+    mthds: "npm:^0.15.0"
+  checksum: 0a0844b233c358b3d456c4bd6bece2583b1e591998020bbed6bf8a84c45f9af5880e8328efb22f04f79b56d85339acdfb128e98aceb115af18d872438c443f52
   languageName: node
   linkType: hard
 
@@ -3471,9 +3471,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mthds@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "mthds@npm:0.14.0"
+"mthds@npm:^0.15.0":
+  version: 0.15.0
+  resolution: "mthds@npm:0.15.0"
   dependencies:
     "@clack/prompts": "npm:^1.0.0"
     chalk: "npm:^5.4.1"
@@ -3486,7 +3486,7 @@ __metadata:
   bin:
     mthds: dist/cli.js
     mthds-agent: dist/agent-cli.js
-  checksum: f234c876a9066688df1b743ae0f0cc8c22c46c1d19f6fd75ef3fae84692c7091b57b5d29bbdee175f7bb37f0ea57419e5f6f7e7d52297fb68e38cd413caccf5b
+  checksum: e9437d1f2528cec407053fe91a072b7cbc3b2fc244a439aaad32a346c9e47a1dce60b0be94c4239d9a7a56cbb472b977c736a0971a66cc4e0eec7a79952a814b
   languageName: node
   linkType: hard
 
@@ -3785,7 +3785,7 @@ __metadata:
   dependencies:
     "@pipelex/lsp": "portal:../../js/lsp"
     "@pipelex/mthds-ui": "npm:0.11.0"
-    "@pipelex/sdk": "npm:0.1.4"
+    "@pipelex/sdk": "npm:0.1.5"
     "@rollup/plugin-commonjs": "npm:^25.0.7"
     "@rollup/plugin-node-resolve": "npm:^15.2.3"
     "@rollup/plugin-replace": "npm:^5.0.5"


### PR DESCRIPTION
## Summary
- Bumps the VS Code extension's `@pipelex/sdk` dependency from `0.1.4` → `0.1.5`.
- Its transitive `mthds` dep follows from `0.14.0` → `0.15.0`. `mthds` stays transitive-only (no direct dependency), consistent with the prior SDK-adoption commit.

## Notes
- No CHANGELOG change needed: the existing `[0.12.1]` entry documents the `@pipelex/sdk` migration without pinning a patch version, so a `0.1.4`→`0.1.5` bump doesn't alter the user-facing description.

## Verification
- `yarn typecheck` — clean (all `@pipelex/sdk` imports and `PipelexValidation*` types resolve).
- `yarn test` — full vitest suite passes against the new SDK, including the validation-backend suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts `@pipelex/sdk`’s `PipelexApiClient` for API validation and bumps `@pipelex/sdk` to 0.1.5, removing the direct `mthds` dependency. Also bumps `@pipelex/mthds-ui` to 0.11.0 (fixes `PipeStructure` rendering) and updates auth to use `PIPELEX_API_KEY`.

- **Refactors**
  - Replaced `MthdsApiClient` with `PipelexApiClient`; imports and types now come from `@pipelex/sdk`.
  - Updated tests and version gate; auth messages now reference `PIPELEX_API_KEY`.
  - Validation narrowing now sourced from the SDK; `mthds` remains transitive-only.

- **Migration**
  - Hosted auth now reads `PIPELEX_API_KEY` (was `MTHDS_API_KEY`).
  - Use “Pipelex: Set Hosted API Key” or set the `PIPELEX_API_KEY` env var.

<sup>Written for commit 5def2b9afc23c1764cf6ad5a4643e9e6d8e0535b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/vscode-pipelex/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

